### PR TITLE
[AC-88] Add Eclipse files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,8 @@ modules/odk.collect/android/*
 
 #git patches
 *.patch
+
+# Eclipse files
+*.project
+*.classpath
+.settings/


### PR DESCRIPTION
This should fix the majority of [AC-88](https://issues.openmrs.org/browse/AC-88), although I didn't add the support library jars. Not sure that we should add those in, what do you think?