### PR TITLE
Fixed AC-152 : Corrected the Dialog Tag being passed in the function

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.2-all.zip

--- a/openmrs-client/src/main/java/org/openmrs/mobile/activities/ACBaseActivity.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/activities/ACBaseActivity.java
@@ -173,7 +173,7 @@ public abstract class ACBaseActivity extends AppCompatActivity {
         bundle.setTextViewMessage(getString(R.string.server_error_dialog_message));
         bundle.setRightButtonAction(CustomFragmentDialog.OnClickAction.DISMISS);
         bundle.setRightButtonText(getString(R.string.dialog_button_ok));
-        createAndShowDialog(bundle, ApplicationConstants.DialogTAG.SOCKET_EXCEPTION_DIALOG_TAG);
+        createAndShowDialog(bundle, ApplicationConstants.DialogTAG.SERVER_ERROR_DIALOG_TAG);
     }
 
     protected void showSocketExceptionErrorDialog() {
@@ -182,7 +182,7 @@ public abstract class ACBaseActivity extends AppCompatActivity {
         bundle.setTextViewMessage(getString(R.string.socket_exception_dialog_message));
         bundle.setRightButtonAction(CustomFragmentDialog.OnClickAction.DISMISS);
         bundle.setRightButtonText(getString(R.string.dialog_button_ok));
-        createAndShowDialog(bundle, ApplicationConstants.DialogTAG.SERVER_ERROR_DIALOG_TAG);
+        createAndShowDialog(bundle, ApplicationConstants.DialogTAG.SOCKET_EXCEPTION_DIALOG_TAG);
     }
 
     public void showNoVisitDialog() {


### PR DESCRIPTION
Wrong tags were being passed as arguments in the method `createAndShowDialog();` in the functions 
`showServerErrorDialog()` and `showSocketExceptionErrorDialog()` 