### PR TITLE
Fixed AC-154: Corrected the string format.

### DIFF
--- a/openmrs-client/src/main/res/values/strings.xml
+++ b/openmrs-client/src/main/res/values/strings.xml
@@ -73,7 +73,7 @@
     <string name="start_visit_dialog_message">Are you sure you want to start visit for %1$s now?</string>
     <!-- Start visit dialog impossible-->
     <string name="start_visit_impossible_dialog_title">Start Visit Impossible</string>
-    <string name="start_visit_impossible_dialog_message">There are already active visit for %1$s. Synchronize patient or close previous visit</string>
+    <string name="start_visit_impossible_dialog_message">There are already active visits of %1$s. Try synchronizing patient or close previous visits</string>
     <!-- Progress dialog -->
     <string name="progress_dialog_message">Please wait ...</string>
     <!-- Capture vitals no visit dialog -->

--- a/openmrs-client/src/main/res/values/strings.xml
+++ b/openmrs-client/src/main/res/values/strings.xml
@@ -73,7 +73,7 @@
     <string name="start_visit_dialog_message">Are you sure you want to start visit for %1$s now?</string>
     <!-- Start visit dialog impossible-->
     <string name="start_visit_impossible_dialog_title">Start Visit Impossible</string>
-    <string name="start_visit_impossible_dialog_message">There are already active visit. Synchronize patient or close previous visit</string>
+    <string name="start_visit_impossible_dialog_message">There are already active visit for %1$s. Synchronize patient or close previous visit</string>
     <!-- Progress dialog -->
     <string name="progress_dialog_message">Please wait ...</string>
     <!-- Capture vitals no visit dialog -->


### PR DESCRIPTION
Previously message text in the dialog was: There are already active visit. Synchronize patient or close previous visit.
Now the warning/error in "ACBaseActivity.java" has been removed. We were not using the argument title declared in the function. Now the new message text in dialog box is:  There are already active visit for Bob Smith. Synchronize patient or close previous visit.