### PR TITLE
AC-193 - Minor search function bugfix

### DIFF
--- a/openmrs-client/src/main/java/org/openmrs/mobile/activities/FindSyncedPatientsActivity.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/activities/FindSyncedPatientsActivity.java
@@ -153,8 +153,10 @@ public class FindSyncedPatientsActivity extends ACBaseActivity {
 
             boolean isPatientNameFitQuery = patientName.length() >= query.length() && patientName.substring(0,query.length()).equals(query);
             boolean isPatientSurnameFitQuery = patientSurname.length() >= query.length() && patientSurname.substring(0,query.length()).equals(query);
-            boolean isPatientIdentifierFitQuery = patientIdentifier.length() >= query.length() && patientIdentifier.substring(0,query.length()).equals(query);
-
+            boolean isPatientIdentifierFitQuery = false;
+            if (patientIdentifier != null) {
+                isPatientIdentifierFitQuery = patientIdentifier.length() >= query.length() && patientIdentifier.substring(0,query.length()).equals(query);
+            }
             if (isPatientNameFitQuery || isPatientSurnameFitQuery || isPatientIdentifierFitQuery) {
                 filteredList.add(patient);
             }


### PR DESCRIPTION
This change prevents NullPointerException when applying filter to patientIdentifier which can be null if not synchronized.
@AvijitGhosh82