### PR TITLE
AC-196 fixed serializer to work with all resources

### DIFF
--- a/openmrs-client/build.gradle
+++ b/openmrs-client/build.gradle
@@ -108,7 +108,12 @@ dependencies {
     compile 'org.jdeferred:jdeferred-android-aar:1.2.4'
     compile 'com.android.support:support-v13:23.4.0'
     compile 'com.michaelpardo:activeandroid:3.1.0-SNAPSHOT'
+    compile 'com.squareup.okhttp3:logging-interceptor:3.2.0'
 
+    testCompile(
+        'org.mockito:mockito-core:1.10.19',
+        'junit:junit:4.12'
+    )
 }
 
 play {

--- a/openmrs-client/src/main/java/org/openmrs/mobile/api/RestServiceBuilder.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/api/RestServiceBuilder.java
@@ -26,6 +26,7 @@ import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
+import okhttp3.logging.HttpLoggingInterceptor;
 import retrofit2.Retrofit;
 import retrofit2.converter.gson.GsonConverterFactory;
 
@@ -43,7 +44,8 @@ public class RestServiceBuilder {
         builder =
                 new Retrofit.Builder()
                         .baseUrl(API_BASE_URL)
-                        .addConverterFactory(buildGsonConverter());
+                        .addConverterFactory(buildGsonConverter())
+                        .client((httpClient).build());
     }
 
     public static <S> S createService(Class<S> serviceClass, String username, String password){
@@ -66,8 +68,10 @@ public class RestServiceBuilder {
                     return chain.proceed(request);
                 }
             });
+            HttpLoggingInterceptor logging = new HttpLoggingInterceptor();
+            logging.setLevel(HttpLoggingInterceptor.Level.BODY);
+            httpClient.addInterceptor(logging);
         }
-
         OkHttpClient client = httpClient.build();
         Retrofit retrofit = builder.client(client).build();
         return retrofit.create(serviceClass);
@@ -83,7 +87,7 @@ public class RestServiceBuilder {
         GsonBuilder gsonBuilder = new GsonBuilder();
         Gson myGson = gsonBuilder
                 .excludeFieldsWithoutExposeAnnotation()
-                .registerTypeAdapter(Resource.class, new ResourceSerializer())
+                .registerTypeHierarchyAdapter(Resource.class, new ResourceSerializer())
                 .create();
 
         return GsonConverterFactory.create(myGson);

--- a/openmrs-client/src/main/java/org/openmrs/mobile/models/retrofit/Person.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/models/retrofit/Person.java
@@ -17,7 +17,7 @@ import java.util.List;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public class Person implements Serializable {
+public class Person extends Resource implements Serializable {
 
     @SerializedName("names")
     @Expose

--- a/openmrs-client/src/main/java/org/openmrs/mobile/utilities/ResourceSerializer.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/utilities/ResourceSerializer.java
@@ -1,17 +1,89 @@
 package org.openmrs.mobile.utilities;
 
+import android.support.annotation.NonNull;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
+import com.google.gson.annotations.Expose;
 
 import org.openmrs.mobile.models.retrofit.Resource;
 
+import java.lang.reflect.Field;
 import java.lang.reflect.Type;
+import java.util.Collection;
 
-public class ResourceSerializer implements JsonSerializer<Resource>{
+public class ResourceSerializer implements JsonSerializer<Resource> {
     @Override
     public JsonElement serialize(Resource src, Type typeOfSrc, JsonSerializationContext context) {
-        return new JsonPrimitive(src.getUuid());
+        Gson myGson = getGson();
+        JsonObject srcJson = new JsonObject();
+        Field[] declaredFields = src.getClass().getDeclaredFields();
+        for (Field field : declaredFields) {
+            if (field.getAnnotation(Expose.class) != null) {
+                field.setAccessible(true);
+                if (Resource.class.isAssignableFrom(field.getType())) {
+                    try {
+                        srcJson.add(field.getName(), serializeField((Resource) field.get(src), context));
+                    } catch (IllegalAccessException e) {
+                        e.printStackTrace();
+                    }
+                } else if (Collection.class.isAssignableFrom(field.getType())) {
+                    try {
+                        Collection collection = ((Collection) field.get(src));
+                        if (collection != null && !collection.isEmpty()) {
+                            if (isResourceCollection(collection)) {
+                                JsonArray jsonArray = new JsonArray();
+                                for (Object resource : collection) {
+                                    jsonArray.add(serializeField((Resource) resource, context));
+                                }
+                                srcJson.add(field.getName(), jsonArray);
+                            } else {
+                                JsonArray jsonArray = new JsonArray();
+                                for (Object object : collection) {
+                                    jsonArray.add(myGson.toJsonTree(object));
+                                }
+                                srcJson.add(field.getName(), jsonArray);
+                            }
+                        }
+                    } catch (IllegalAccessException e) {
+                        e.printStackTrace();
+                    }
+                } else {
+                    try {
+                        srcJson.add(field.getName(), myGson.toJsonTree(field.get(src)));
+                    } catch (IllegalAccessException e) {
+                        e.printStackTrace();
+                    }
+                }
+            }
+        }
+        return srcJson;
+    }
+
+    @NonNull
+    private Gson getGson() {
+        GsonBuilder gsonBuilder = new GsonBuilder();
+        return gsonBuilder
+                .excludeFieldsWithoutExposeAnnotation()
+                .create();
+    }
+
+    private JsonElement serializeField(Resource src, JsonSerializationContext context) {
+        if (src.getUuid() != null) {
+            return new JsonPrimitive(src.getUuid());
+        } else {
+            return context.serialize(src);
+        }
+    }
+
+
+    private boolean isResourceCollection(Collection collection) {
+        return Resource.class.isAssignableFrom(collection.toArray()[0].getClass());
     }
 }

--- a/openmrs-client/src/test/java/org/openmrs/mobile/test/ResourceSerializerTest.java
+++ b/openmrs-client/src/test/java/org/openmrs/mobile/test/ResourceSerializerTest.java
@@ -1,0 +1,124 @@
+package org.openmrs.mobile.test;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSerializationContext;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.openmrs.mobile.models.Location;
+import org.openmrs.mobile.models.retrofit.IdentifierType;
+import org.openmrs.mobile.models.retrofit.Patient;
+import org.openmrs.mobile.models.retrofit.PatientIdentifier;
+import org.openmrs.mobile.models.retrofit.Person;
+import org.openmrs.mobile.models.retrofit.PersonName;
+import org.openmrs.mobile.utilities.DateUtils;
+import org.openmrs.mobile.utilities.ResourceSerializer;
+
+import java.util.Arrays;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsNot.not;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ResourceSerializerTest {
+
+    @Mock
+    JsonSerializationContext context;
+
+    @Test
+    public void shouldSerializeResourceFieldAsFullWhenNoUuidPresent(){
+        when(context.serialize(any())).thenReturn(getJsonObject());
+        Patient patient = generatePatient(false);
+        JsonElement serialize = new ResourceSerializer().serialize(patient, Patient.class, context);
+        assertThat(serialize.toString(), containsString("\"fullObject\":\"true\""));
+    }
+
+    @Test
+    public void shouldSerializeResourceFieldToUuidOnlyWhenUuidPresent(){
+        when(context.serialize(any())).thenReturn(getJsonObject());
+        Patient patient = generatePatient(true);
+        JsonElement serialize = new ResourceSerializer().serialize(patient, Patient.class, context);
+        assertThat(serialize.toString(), containsString("\"person\":\"PersonUUID\""));
+    }
+
+
+    @Test
+    public void shouldNotThrowNPEWhenCollectionIsNull(){
+        when(context.serialize(any())).thenReturn(getJsonObject());
+        Patient patient = generatePatient(false);
+        patient.setIdentifiers(null);
+        JsonElement serialize = new ResourceSerializer().serialize(patient, Patient.class, context);
+        assertThat(serialize.toString(), not(containsString("\"identifiers\":")));
+    }
+
+    @Test
+    public void shouldNotSerializeFieldWithoutExposeAnnotation(){
+        when(context.serialize(any())).thenReturn(getJsonObject());
+        Patient patient = generatePatient(false);
+        patient.setId(10000L);
+        JsonElement serialize = new ResourceSerializer().serialize(patient, Patient.class, context);
+        assertThat(serialize.toString(), not(containsString("\"id\":")));
+    }
+
+    private JsonElement getJsonObject() {
+        JsonObject jsonObject = new JsonObject();
+        jsonObject.addProperty("fullObject", "true");
+        return jsonObject;
+    }
+
+    private Patient generatePatient(boolean withPersonUuid) {
+        Patient patient = new Patient();
+        if (withPersonUuid) {
+            patient.setPerson(generatePersonWithUuid());
+        } else {
+            patient.setPerson(generatePersonWithoutUuid());
+        }
+        patient.setVoided(false);
+        patient.setIdentifiers(Arrays.asList(generateIdentifier()));
+        return patient;
+    }
+
+    private Person generatePersonWithoutUuid() {
+        Person person = new Person();
+        person.setBirthdate(DateUtils.convertTime(System.currentTimeMillis()));
+        PersonName  personName = new PersonName();
+        personName.setFamilyName("family");
+        personName.setGivenName("given");
+        personName.setMiddleName("middle");
+        person.setNames(Arrays.asList(personName));
+        person.setGender("M");
+        return person;
+    }
+
+    private Person generatePersonWithUuid() {
+        Person person = new Person();
+        person.setBirthdate(DateUtils.convertTime(System.currentTimeMillis()));
+        PersonName  personName = new PersonName();
+        personName.setFamilyName("family");
+        personName.setGivenName("given");
+        personName.setMiddleName("middle");
+        person.setNames(Arrays.asList(personName));
+        person.setGender("M");
+        person.setUuid("PersonUUID");
+        return person;
+    }
+
+    private PatientIdentifier generateIdentifier() {
+        PatientIdentifier patientIdentifier = new PatientIdentifier();
+        IdentifierType identifierType = new IdentifierType();
+        identifierType.setUuid("identifierTypeUUID");
+        patientIdentifier.setIdentifierType(identifierType);
+        Location location = new Location();
+        location.setUuid("locationUUID");
+        patientIdentifier.setLocation(location);
+        patientIdentifier.setUuid("patientIdentifierUUID");
+        return patientIdentifier;
+    }
+
+}


### PR DESCRIPTION
Sooo, the first serializer didn't work at all... We've noticed that with @tmarzeion when working on changing Visit model to match retrofit. 
I have modified it now to work with all classes that are Resources. 
Here is how it works:
when you post Resource object via retrofit this custom serializer checks all declared fields. If there is a Resource with uuid set it will serialize it to uuid only. When uuid is null it will serialize full object. 
When declared field is a collection, serializer iterates through it and does the same as above. It the collection contains objects that are not Resources,  it will be serializes with default gson serializer.

@rkorytkowski @AvijitGhosh82 @tmarzeion 
What do you think about that ? 
This is made to make posting object easier. Instead writing custom serializers for each objects e.g Patient/Visit we can use only this one. 
I have added some unit tests and also tested it manually by posting Patient and Visit.