### PR TITLE
AC-265: Addresses switched when syncing patient from server

### DIFF
--- a/openmrs-client/src/main/java/org/openmrs/mobile/models/PersonAddress.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/models/PersonAddress.java
@@ -24,10 +24,10 @@ public class PersonAddress implements Serializable {
     private Boolean preferred;
     @SerializedName("address1")
     @Expose
-    private String address2;
+    private String address1;
     @SerializedName("address2")
     @Expose
-    private String address1;
+    private String address2;
     @SerializedName("cityVillage")
     @Expose
     private String cityVillage;


### PR DESCRIPTION
AC-265: Addresses switched when syncing patient from server
https://issues.openmrs.org/browse/AC-265
I fixed switching address in Android client.