### PR TITLE
Added support for decimal numeric values in forms

### DIFF
--- a/openmrs-client/src/main/java/org/openmrs/mobile/activities/formdisplay/FormDisplayPageFragment.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/activities/formdisplay/FormDisplayPageFragment.java
@@ -128,7 +128,12 @@ public class FormDisplayPageFragment extends Fragment implements FormDisplayCont
             ed.setUpperlimit(-1.0);
         }
         ed.setTextSize(TypedValue.COMPLEX_UNIT_SP,16);
-        ed.setInputType(InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_FLAG_DECIMAL);
+        if (question.getQuestionOptions().isAllowDecimal()) {
+            ed.setInputType(InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_FLAG_DECIMAL);
+        }
+        else {
+            ed.setInputType(InputType.TYPE_CLASS_NUMBER);
+        }
         InputField field = new InputField(question.getQuestionOptions().getConcept());
         ed.setId(field.getId());
         InputField inputField = getInputField(field.getConcept());

--- a/openmrs-client/src/main/java/org/openmrs/mobile/models/QuestionOptions.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/models/QuestionOptions.java
@@ -36,6 +36,11 @@ public class QuestionOptions implements Serializable {
     @Expose
     private String min;
 
+    // For numeric values
+    @SerializedName("allowDecimal")
+    @Expose
+    private boolean allowDecimal;
+
     // For select radio boxes
     @SerializedName("answers")
     @Expose
@@ -91,6 +96,14 @@ public class QuestionOptions implements Serializable {
 
     public void setMin(String min) {
         this.min = min;
+    }
+
+    public boolean isAllowDecimal() {
+        return allowDecimal;
+    }
+
+    public void setAllowDecimal(boolean allowDecimal) {
+        this.allowDecimal = allowDecimal;
     }
 
     public List<Answer> getAnswers() {


### PR DESCRIPTION
It is now possible to describe "allowDecimal" property in form's resource's json (default false).
When allowDecimal is disabled, question field doesn't allow to input commas.