### PR TITLE
AC-283: Fixed selecting patients in Download Patient

### DIFF
--- a/openmrs-client/src/main/java/org/openmrs/mobile/activities/lastviewedpatients/LastViewedPatientRecyclerViewAdapter.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/activities/lastviewedpatients/LastViewedPatientRecyclerViewAdapter.java
@@ -57,6 +57,14 @@ class LastViewedPatientRecyclerViewAdapter extends RecyclerView.Adapter<LastView
         this.selectedPatientPositions = new HashSet<>();
     }
 
+    public Set<Integer> getSelectedPatientPositions() {
+        return selectedPatientPositions;
+    }
+
+    public void setSelectedPatientPositions(Set<Integer> selectedPatientPositions) {
+        this.selectedPatientPositions = selectedPatientPositions;
+    }
+
     @Override
     public LastViewedPatientRecyclerViewAdapter.PatientViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
         View itemView = LayoutInflater.from(parent.getContext()).inflate(R.layout.find_last_viewed_patients_row, parent, false);

--- a/openmrs-client/src/main/java/org/openmrs/mobile/activities/lastviewedpatients/LastViewedPatientsFragment.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/activities/lastviewedpatients/LastViewedPatientsFragment.java
@@ -31,6 +31,7 @@ import org.openmrs.mobile.models.Patient;
 import org.openmrs.mobile.utilities.ToastUtil;
 
 import java.util.List;
+import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -40,6 +41,7 @@ public class LastViewedPatientsFragment extends Fragment implements LastViewedPa
     private ProgressBar mSpinner;
     private RecyclerView mPatientsRecyclerView;
     private LastViewedPatientRecyclerViewAdapter mAdapter;
+    private Set<Integer> selectedPatientPositions;
     public SwipeRefreshLayout mSwipeRefreshLayout;
 
     LastViewedPatientsContract.Presenter mPresenter;
@@ -68,6 +70,12 @@ public class LastViewedPatientsFragment extends Fragment implements LastViewedPa
     public void onResume() {
         super.onResume();
         mPresenter.start();
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        selectedPatientPositions = mAdapter.getSelectedPatientPositions();
     }
 
     @Override
@@ -106,6 +114,7 @@ public class LastViewedPatientsFragment extends Fragment implements LastViewedPa
 
     public void updateList(List<Patient> patientList) {
         mAdapter = new LastViewedPatientRecyclerViewAdapter(this.getActivity(), patientList);
+        if (selectedPatientPositions!= null) mAdapter.setSelectedPatientPositions(selectedPatientPositions);
         mPatientsRecyclerView.setAdapter(mAdapter);
     }
 


### PR DESCRIPTION
https://issues.openmrs.org/browse/AC-283
AC-283: Selecting from Download Patient doesn't work after repopening app
I fixed selecting patients in Download Patients view. Now patients are selected even after reopening app.