### PR TITLE
AC-285: Patients' data downloaded again when activity resumes

### DIFF
--- a/openmrs-client/src/main/java/org/openmrs/mobile/activities/lastviewedpatients/LastViewedPatientRecyclerViewAdapter.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/activities/lastviewedpatients/LastViewedPatientRecyclerViewAdapter.java
@@ -56,6 +56,10 @@ class LastViewedPatientRecyclerViewAdapter extends RecyclerView.Adapter<LastView
         this.selectedPatientPositions = new HashSet<>();
     }
 
+    public List<Patient> getmItems() {
+        return mItems;
+    }
+
     @Override
     public LastViewedPatientRecyclerViewAdapter.PatientViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
         View itemView = LayoutInflater.from(parent.getContext()).inflate(R.layout.find_last_viewed_patients_row, parent, false);

--- a/openmrs-client/src/main/java/org/openmrs/mobile/activities/lastviewedpatients/LastViewedPatientsActivity.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/activities/lastviewedpatients/LastViewedPatientsActivity.java
@@ -20,6 +20,7 @@ import android.support.v7.app.ActionBar;
 import android.support.v7.widget.SearchView;
 import android.view.Menu;
 import android.view.MenuItem;
+import android.view.View;
 
 import org.openmrs.mobile.R;
 import org.openmrs.mobile.activities.ACBaseActivity;
@@ -93,6 +94,19 @@ public class LastViewedPatientsActivity extends ACBaseActivity {
                 return true;
             }
         });
+
+        findPatientView.addOnAttachStateChangeListener(new View.OnAttachStateChangeListener() {
+            @Override
+            public void onViewAttachedToWindow(View view) {
+                // nothing to do
+            }
+
+            @Override
+            public void onViewDetachedFromWindow(View view) {
+                ((LastViewedPatientsPresenter) mPresenter).setLastQueryEmpty();
+            }
+        });
+
         return true;
     }
 

--- a/openmrs-client/src/main/java/org/openmrs/mobile/activities/lastviewedpatients/LastViewedPatientsFragment.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/activities/lastviewedpatients/LastViewedPatientsFragment.java
@@ -30,18 +30,19 @@ import org.openmrs.mobile.R;
 import org.openmrs.mobile.models.Patient;
 import org.openmrs.mobile.utilities.ToastUtil;
 
+import java.io.Serializable;
 import java.util.List;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
 public class LastViewedPatientsFragment extends Fragment implements LastViewedPatientsContract.View {
 
+    private static final String PATIENT_LIST = "patient_list";
     private TextView mEmptyList;
     private ProgressBar mSpinner;
     private RecyclerView mPatientsRecyclerView;
     private LastViewedPatientRecyclerViewAdapter mAdapter;
     public SwipeRefreshLayout mSwipeRefreshLayout;
-
     private LastViewedPatientsContract.Presenter mPresenter;
 
     @Override
@@ -61,14 +62,19 @@ public class LastViewedPatientsFragment extends Fragment implements LastViewedPa
                 mAdapter.finishActionMode();
             }
         });
+        if (savedInstanceState != null) {
+            List<Patient> patientList = (List<Patient>) savedInstanceState.getSerializable(PATIENT_LIST);
+            if (patientList == null) {
+                mPresenter.start();
+            } else {
+                updateList(patientList);
+            }
+        } else {
+            mPresenter.start();
+        }
         return root;
     }
 
-    @Override
-    public void onResume() {
-        super.onResume();
-        mPresenter.start();
-    }
 
     @Override
     public boolean isActive() {
@@ -127,4 +133,15 @@ public class LastViewedPatientsFragment extends Fragment implements LastViewedPa
     public void showErrorToast(String message) {
         ToastUtil.error(message);
     }
+
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        if (mAdapter != null) {
+            List<Patient> patientList = mAdapter.getmItems();
+            outState.putSerializable(PATIENT_LIST, (Serializable) patientList);
+        }
+    }
+
+
 }

--- a/openmrs-client/src/main/java/org/openmrs/mobile/activities/lastviewedpatients/LastViewedPatientsPresenter.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/activities/lastviewedpatients/LastViewedPatientsPresenter.java
@@ -41,7 +41,7 @@ public class LastViewedPatientsPresenter implements LastViewedPatientsContract.P
     private RestApi restApi;
 
     private String mQuery;
-    private String mLastQuery = "QUERY";
+    private String lastQuery = "";
 
     public LastViewedPatientsPresenter(@NonNull LastViewedPatientsContract.View mLastViewedPatientsView) {
         this.mLastViewedPatientsView = mLastViewedPatientsView;
@@ -91,7 +91,7 @@ public class LastViewedPatientsPresenter implements LastViewedPatientsContract.P
 
     public void findPatients(String query) {
         setViewBeforePatientDownload();
-        mLastQuery = query;
+        lastQuery = query;
         Call<Results<Patient>> call = restApi.getPatients(query, ApplicationConstants.API.FULL);
         call.enqueue(new Callback<Results<Patient>>() {
             @Override
@@ -147,7 +147,7 @@ public class LastViewedPatientsPresenter implements LastViewedPatientsContract.P
 
     public void updateLastViewedList(String query) {
         mQuery = query;
-        if (query.isEmpty() && !mLastQuery.isEmpty()) {
+        if (query.isEmpty() && !lastQuery.isEmpty()) {
             updateLastViewedList();
         }
     }
@@ -160,6 +160,10 @@ public class LastViewedPatientsPresenter implements LastViewedPatientsContract.P
         else {
             updateLastViewedList();
         }
+    }
+
+    public void setLastQueryEmpty() {
+        lastQuery = "";
     }
 
 }


### PR DESCRIPTION
The patients' data was downloading again and again because whenever fragment resumed, presenter started and it initiates downloading. The data was also downloaded whenever the search query is empty and it is always empty when the fragment is starting.