### PR TITLE
AC-323 DatePicker prevents future dates as DOB in registration form

### DIFF
--- a/openmrs-client/src/main/java/org/openmrs/mobile/activities/addeditpatient/AddEditPatientFragment.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/activities/addeditpatient/AddEditPatientFragment.java
@@ -401,6 +401,7 @@ public class AddEditPatientFragment extends Fragment implements AddEditPatientCo
                             bdt=birthdate.toDateTimeAtStartOfDay().toDateTime();
                         }
                     }, cYear, cMonth, cDay);
+                    mDatePicker.getDatePicker().setMaxDate(System.currentTimeMillis());
                     mDatePicker.setTitle("Select Date");
                     mDatePicker.show();  }
             });


### PR DESCRIPTION
Now the user cannot select future dates as Date of Birth in the registration form, as they have been disabled. Here is a screen-shot

![screenshot_20170117-200015 1](https://cloud.githubusercontent.com/assets/8321130/22024316/97ea236e-dcef-11e6-8f9b-6a993d477023.png)

