### PR TITLE
AC-329 List of countries don't show automatically

### DIFF
--- a/openmrs-client/src/main/java/org/openmrs/mobile/activities/addeditpatient/AddEditPatientFragment.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/activities/addeditpatient/AddEditPatientFragment.java
@@ -54,6 +54,7 @@ import org.openmrs.mobile.utilities.ToastUtil;
 import org.openmrs.mobile.utilities.ViewUtils;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.List;
 
@@ -88,6 +89,8 @@ public class AddEditPatientFragment extends Fragment implements AddEditPatientCo
     private TextView countryerror;
 
     private Button submitConfirm;
+
+    private String[] countries;
 
 
     @Override
@@ -354,7 +357,7 @@ public class AddEditPatientFragment extends Fragment implements AddEditPatientCo
     }
 
     private void addSuggestionsToAutoCompleTextView() {
-        String[] countries = getContext().getResources().getStringArray(R.array.countries_array);
+        countries = getContext().getResources().getStringArray(R.array.countries_array);
         ArrayAdapter<String> adapter = new ArrayAdapter<>(getContext(),
                 android.R.layout.simple_dropdown_item_1line, countries);
         edcountry.setAdapter(adapter);
@@ -369,6 +372,18 @@ public class AddEditPatientFragment extends Fragment implements AddEditPatientCo
             }
         });
 
+        edcountry.setThreshold(2);
+        edcountry.setOnFocusChangeListener(new View.OnFocusChangeListener() {
+            @Override
+            public void onFocusChange(View v, boolean hasFocus) {
+                if (edcountry.getText().length() >= edcountry.getThreshold()) {
+                    edcountry.showDropDown();
+                }
+                if (Arrays.asList(countries).contains(edcountry.getText().toString())) {
+                    edcountry.dismissDropDown();
+                }
+            }
+        });
         if (eddob != null) {
             eddob.setOnClickListener(new View.OnClickListener() {
 

--- a/openmrs-client/src/main/res/layout/fragment_patient_info.xml
+++ b/openmrs-client/src/main/res/layout/fragment_patient_info.xml
@@ -387,7 +387,7 @@
                                 android:focusable="true"
                                 android:imeOptions="actionNext"
                                 android:hint="@string/patient_country_label"
-                                android:inputType="text"
+                                android:inputType="textCapSentences"
                                 android:maxLines="1"
                                 android:textSize="14sp" />
 


### PR DESCRIPTION
Now when the user taps "Country" field in Register Patient the country suggestions are shown even if the user doesn't type anything.

![screenshot_20170118-133906](https://cloud.githubusercontent.com/assets/16754547/22056593/d0c4d732-dd86-11e6-9322-a788941e6dcc.png)
