### PR TITLE
AC-327 Fixed text size in landscape view in 'Encounters'

### DIFF
--- a/openmrs-client/src/main/res/layout-land/list_visit_group.xml
+++ b/openmrs-client/src/main/res/layout-land/list_visit_group.xml
@@ -35,14 +35,18 @@
             android:id="@+id/listVisitGroupEncounterIcon"
             android:contentDescription="@string/visit_encounter_icon"
             android:layout_gravity="center_vertical"
-            android:layout_width="55dp"
-            android:layout_height="55dp" />
+            android:layout_width="40dp"
+            android:layout_height="40dp"
+            android:layout_marginStart="@dimen/visit_dashboard_encounter_type_icon_margin"
+            android:layout_marginLeft="@dimen/visit_dashboard_encounter_type_icon_margin"
+            android:layout_marginEnd="@dimen/visit_dashboard_encounter_type_icon_margin"
+            android:layout_marginRight="@dimen/visit_dashboard_encounter_type_icon_margin"/>
 
         <TextView
             android:id="@+id/listVisitGroupEncounterName"
             android:layout_width="match_parent"
             android:layout_height="55dp"
-            android:textSize="26sp"
+            android:textSize="22sp"
             android:paddingRight="3dp"
             android:paddingLeft="3dp"
             android:layout_gravity="center_vertical"
@@ -64,7 +68,7 @@
             android:id="@+id/listVisitGroupDetailsSelector"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:textSize="24sp"
+            android:textSize="20sp"
             android:paddingLeft="15dp"
             android:paddingRight="10dp" />
 


### PR DESCRIPTION
Now the text size and icon size in landscape mode in 'Encounters' is consistent with the portrait mode. Here is the screen shot- 
![screenshot_20170119-235712](https://cloud.githubusercontent.com/assets/8321130/22124241/005abe38-deb5-11e6-8d0e-654178d015c2.png)




