### PR TITLE
AC-326 Text color is preserved during orientation change in Form Entry

### DIFF
--- a/openmrs-client/src/main/java/org/openmrs/mobile/activities/formdisplay/FormDisplayPageFragment.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/activities/formdisplay/FormDisplayPageFragment.java
@@ -83,6 +83,7 @@ public class FormDisplayPageFragment extends Fragment implements FormDisplayCont
             inputFields = formFieldsWrapper.getInputFields();
             for(InputField field:inputFields){
                 if(field.getIsRed()==true){
+
                     RangeEditText ed = (RangeEditText) getActivity().findViewById(field.getId());
                     ed.setTextColor(ContextCompat.getColor(OpenMRS.getInstance(), R.color.red));
                 }

--- a/openmrs-client/src/main/java/org/openmrs/mobile/activities/formdisplay/FormDisplayPageFragment.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/activities/formdisplay/FormDisplayPageFragment.java
@@ -81,6 +81,12 @@ public class FormDisplayPageFragment extends Fragment implements FormDisplayCont
         if (savedInstanceState != null) {
             FormFieldsWrapper formFieldsWrapper = (FormFieldsWrapper) savedInstanceState.getSerializable(ApplicationConstants.BundleKeys.FORM_FIELDS_BUNDLE);
             inputFields = formFieldsWrapper.getInputFields();
+            for(InputField field:inputFields){
+                if(field.getIsRed()==true){
+                    RangeEditText ed = (RangeEditText) getActivity().findViewById(field.getId());
+                    ed.setTextColor(ContextCompat.getColor(OpenMRS.getInstance(), R.color.red));
+                }
+            }
             selectOneFields = formFieldsWrapper.getSelectOneFields();
         }
     }
@@ -103,6 +109,7 @@ public class FormDisplayPageFragment extends Fragment implements FormDisplayCont
         RangeEditText ed = new RangeEditText(getActivity());
         ed.setName(question.getLabel());
         ed.setSingleLine(true);
+
         if (question.getQuestionOptions().getMax()!=null)
         {   ed.setHint(question.getLabel()+" ["+question.getQuestionOptions().getMin()+"-"+
                 question.getQuestionOptions().getMax()+"]");
@@ -315,10 +322,14 @@ public class FormDisplayPageFragment extends Fragment implements FormDisplayCont
     public List<InputField> getInputFields() {
         for (InputField field:inputFields) {
             RangeEditText ed=(RangeEditText) getActivity().findViewById(field.getId());
-            if(!isEmpty(ed))
+            if(!isEmpty(ed)){
                 field.setValue(Double.parseDouble(ed.getText().toString()));
-            else
+                boolean isRed=(ed.getCurrentTextColor()==ContextCompat.getColor(OpenMRS.getInstance(), R.color.red))?true:false ;
+                field.setIsRed(isRed);
+            }
+            else{
                 field.setValue(-1.0);
+            }
         }
         return inputFields;
     }

--- a/openmrs-client/src/main/java/org/openmrs/mobile/activities/patientdashboard/PatientDashboardActivity.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/activities/patientdashboard/PatientDashboardActivity.java
@@ -101,7 +101,6 @@ public class PatientDashboardActivity extends ACBaseActivity {
             @Override
             public void onTabSelected(int position) {
                 viewPager.setCurrentItem(position);
-                viewPager.getAdapter().notifyDataSetChanged();
             }
         });
     }

--- a/openmrs-client/src/main/java/org/openmrs/mobile/utilities/InputField.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/utilities/InputField.java
@@ -24,6 +24,7 @@ public class InputField implements Serializable, Parcelable {
     private int id;
     private String concept;
     private double value = -1.0;
+    private boolean isRed = false;
 
     public InputField(String concept) {
         this.concept = concept;
@@ -54,6 +55,10 @@ public class InputField implements Serializable, Parcelable {
         return value;
     }
 
+    public void setIsRed(boolean isRed) {this.isRed=isRed; }
+
+    public boolean getIsRed() {return isRed; }
+
     @Override
     public int describeContents() {
         return 0;
@@ -64,12 +69,14 @@ public class InputField implements Serializable, Parcelable {
         dest.writeInt(this.id);
         dest.writeString(this.concept);
         dest.writeDouble(this.value);
+        dest.writeInt(this.isRed?1:0);
     }
 
     protected InputField(Parcel in) {
         this.id = in.readInt();
         this.concept = in.readString();
         this.value = in.readDouble();
+        this.isRed=(in.readInt()==1)?true:false;
     }
 
     public static final Parcelable.Creator<InputField> CREATOR = new Parcelable.Creator<InputField>() {

--- a/openmrs-client/src/main/java/org/openmrs/mobile/utilities/InputField.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/utilities/InputField.java
@@ -14,6 +14,7 @@
 
 package org.openmrs.mobile.utilities;
 
+import android.graphics.Color;
 import android.os.Parcel;
 import android.os.Parcelable;
 
@@ -25,6 +26,7 @@ public class InputField implements Serializable, Parcelable {
     private String concept;
     private double value = -1.0;
     private boolean isRed = false;
+
 
     public InputField(String concept) {
         this.concept = concept;

--- a/openmrs-client/src/main/res/layout-land/list_visit_group.xml
+++ b/openmrs-client/src/main/res/layout-land/list_visit_group.xml
@@ -35,14 +35,18 @@
             android:id="@+id/listVisitGroupEncounterIcon"
             android:contentDescription="@string/visit_encounter_icon"
             android:layout_gravity="center_vertical"
-            android:layout_width="55dp"
-            android:layout_height="55dp" />
+            android:layout_width="40dp"
+            android:layout_height="40dp"
+            android:layout_marginStart="@dimen/visit_dashboard_encounter_type_icon_margin"
+            android:layout_marginLeft="@dimen/visit_dashboard_encounter_type_icon_margin"
+            android:layout_marginEnd="@dimen/visit_dashboard_encounter_type_icon_margin"
+            android:layout_marginRight="@dimen/visit_dashboard_encounter_type_icon_margin"/>
 
         <TextView
             android:id="@+id/listVisitGroupEncounterName"
             android:layout_width="match_parent"
             android:layout_height="55dp"
-            android:textSize="26sp"
+            android:textSize="22sp"
             android:paddingRight="3dp"
             android:paddingLeft="3dp"
             android:layout_gravity="center_vertical"
@@ -64,7 +68,7 @@
             android:id="@+id/listVisitGroupDetailsSelector"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:textSize="24sp"
+            android:textSize="20sp"
             android:paddingLeft="15dp"
             android:paddingRight="10dp" />
 

--- a/openmrs-client/src/main/res/layout/fragment_patient_info.xml
+++ b/openmrs-client/src/main/res/layout/fragment_patient_info.xml
@@ -387,7 +387,7 @@
                                 android:focusable="true"
                                 android:imeOptions="actionNext"
                                 android:hint="@string/patient_country_label"
-                                android:inputType="text"
+                                android:inputType="textCapSentences"
                                 android:maxLines="1"
                                 android:textSize="14sp" />
 


### PR DESCRIPTION
In all the form categories under 'Form Entry', the highlighted text color (red when entry is out of range) is preserved during orientation change. Here are a few screen shots- 
![screenshot_20170121-032821](https://cloud.githubusercontent.com/assets/8321130/22167339/b8db4cf8-df8b-11e6-8438-fcef2e0576c8.png)
![screenshot_20170121-033530](https://cloud.githubusercontent.com/assets/8321130/22167345/c0245c16-df8b-11e6-8b1b-3d5d0b994a12.png)

 