### PR TITLE
AC 374 - Instant warning on entering values beyond specified ranges in forms

### DIFF
--- a/openmrs-client/src/main/java/org/openmrs/mobile/activities/formdisplay/FormDisplayPageFragment.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/activities/formdisplay/FormDisplayPageFragment.java
@@ -17,6 +17,7 @@ import android.support.v4.content.ContextCompat;
 import android.text.InputType;
 import android.util.TypedValue;
 import android.view.Gravity;
+import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -114,6 +115,22 @@ public class FormDisplayPageFragment extends Fragment implements FormDisplayCont
                     question.getQuestionOptions().getMax() + "]");
             ed.setUpperlimit(Double.parseDouble(question.getQuestionOptions().getMax()));
             ed.setLowerlimit(Double.parseDouble(question.getQuestionOptions().getMin()));
+            ed.setOnKeyListener(new View.OnKeyListener() {
+                @Override
+                public boolean onKey(View v, int keyCode, KeyEvent event) {
+                    double max = Double.parseDouble(question.getQuestionOptions().getMax());
+                    double min = Double.parseDouble(question.getQuestionOptions().getMin());
+                    double value= -1;
+
+                    if(!ed.getText().toString().trim().equals("")){
+                        value =Double.parseDouble(ed.getText().toString().trim());
+                    }
+                    if(value != -1 && (value < min || value > max)){
+                        ed.setError("Value must be between " + min + " and " + max);
+                    }
+                    return false;
+                }
+            });
         } else {
             ed.setHint(question.getLabel());
             ed.setLowerlimit(-1.0);


### PR DESCRIPTION
Earlier, if the user enters values if forms which are out of range, toast messages are given only after pressing the submit button. Now, instant warning messages to be given as soon as a value is entered beyond the specified range.
![https://issues.openmrs.org/secure/attachment/48604/Screenshot_20170205-134900.png](https://issues.openmrs.org/secure/attachment/48604/Screenshot_20170205-134900.png)