### PR TITLE
AC-394: Add back button to PatientPhotoActivity action bar.

### DIFF
--- a/openmrs-client/src/main/java/org/openmrs/mobile/activities/patientdashboard/details/PatientPhotoActivity.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/activities/patientdashboard/details/PatientPhotoActivity.java
@@ -20,6 +20,7 @@ import android.graphics.BitmapFactory;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
+import android.view.MenuItem;
 import android.widget.ImageView;
 
 import org.openmrs.mobile.R;
@@ -44,7 +45,18 @@ public class PatientPhotoActivity extends AppCompatActivity {
             String patientName = getIntent().getStringExtra("name");
             setSupportActionBar(toolbar);
             getSupportActionBar().setTitle(patientName);
+            getSupportActionBar().setDisplayHomeAsUpEnabled(true);
         }
     }
 
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        switch (item.getItemId()) {
+            case android.R.id.home:
+                this.finish();
+                return true;
+            default:
+                return super.onOptionsItemSelected(item);
+        }
+    }
 }


### PR DESCRIPTION
Pressing the back button will return to the parent activity, i.e.
the PatientDashboardActivity.

Ref ticket: https://issues.openmrs.org/browse/AC-394
