### PR TITLE
[AC-431] Make the toast mesage standard

### DIFF
--- a/openmrs-client/src/main/java/org/openmrs/mobile/activities/login/LoginPresenter.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/activities/login/LoginPresenter.java
@@ -175,7 +175,8 @@ public class LoginPresenter extends BasePresenter implements LoginContract.Prese
             if (mOpenMRS.isUserLoggedOnline() && url.equals(mOpenMRS.getLastLoginServerUrl())) {
                 if (mOpenMRS.getUsername().equals(username) && mOpenMRS.getPassword().equals(password)) {
                     mOpenMRS.setSessionToken(mOpenMRS.getLastSessionToken());
-                    loginView.showToast("LoggedIn in offline mode.", ToastUtil.ToastType.NOTICE);
+                    loginView.showToast(R.string.login_offline_toast_message,
+                            ToastUtil.ToastType.NOTICE);
                     loginView.userAuthenticated();
                     loginView.finishLoginActivity();
                 } else {

--- a/openmrs-client/src/main/res/values/strings.xml
+++ b/openmrs-client/src/main/res/values/strings.xml
@@ -60,6 +60,7 @@
 
     <!-- Offline Mode -->
     <string name="offline_mode_unsupported_in_first_login">Offline mode is not supported during first login.Enable online mode and then try again.</string>
+    <string name="login_offline_toast_message">You are now in offline mode.</string>
 
     <!-- Connection Timeout dialog -->
     <string name="conn_timeout_dialog_title">Connection Failed</string>

--- a/openmrs-client/src/test/java/org/openmrs/mobile/test/presenters/LoginPresenterTest.java
+++ b/openmrs-client/src/test/java/org/openmrs/mobile/test/presenters/LoginPresenterTest.java
@@ -184,7 +184,7 @@ public class LoginPresenterTest extends ACUnitTestBaseRx {
         when(openMRS.getLastLoginServerUrl()).thenReturn(url);
         presenter.login(user, password, url, url);
 
-        verify(view).showToast(anyString(), any());
+        verify(view).showToast(anyInt(), any());
         verify(view).userAuthenticated();
         verify(view).finishLoginActivity();
     }


### PR DESCRIPTION
When a user logs in using offline mode then a toast message shows up "LoggedIn in offline mode" which is still informative but somewhat confusing. I changed it to "You are now in offline mode" whose meaning is direct and straightforward.
see https://issues.openmrs.org/browse/AC-431