### PR TITLE
AC-446: Variable obscreateList is redundant

### DIFF
--- a/openmrs-client/src/main/java/org/openmrs/mobile/models/Encountercreate.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/models/Encountercreate.java
@@ -133,13 +133,11 @@ public class Encountercreate extends Model implements Serializable{
 
     public void setObslist()
     {
-        this.obslist=gson.toJson(observations,obscreatetype);
+        this.obslist = gson.toJson(observations,obscreatetype);
     }
 
     public void pullObslist() {
-
-        List<Obscreate> obscreateList=gson.fromJson(this.obslist,obscreatetype);
-        this.observations=obscreateList;
+        this.observations = gson.fromJson(this.obslist,obscreatetype);
     }
 
 


### PR DESCRIPTION
**JIRA Issue link:**  https://issues.openmrs.org/browse/AC-446
**JIRA Summary:**
1. The variable `obscreateList` is redundant. Rather than creating a new variable, just assign value from the `gson.fromJson()` statement.
2. Also, add spaces on both sides of `equal to` in this function and the function above it.