### PR TITLE
AC-484: Made SecretKeyGenerator.bytesToHex() more efficient

### DIFF
--- a/openmrs-client/src/main/java/org/openmrs/mobile/security/SecretKeyGenerator.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/security/SecretKeyGenerator.java
@@ -51,14 +51,15 @@ public final class SecretKeyGenerator {
         }
 
         int len = data.length;
-        String str = "";
+        StringBuilder stringBuilder = new StringBuilder();
         for (int i = 0; i < len; i++) {
             if ((data[i] & 0xFF) < 16) {
-                str = str + "0" + java.lang.Integer.toHexString(data[i] & 0xFF);
+                stringBuilder.append('0');
+                stringBuilder.append(java.lang.Integer.toHexString(data[i] & 0xFF));
             } else {
-                str = str + java.lang.Integer.toHexString(data[i] & 0xFF);
+                stringBuilder.append(java.lang.Integer.toHexString(data[i] & 0xFF));
             }
         }
-        return str;
+        return stringBuilder.toString();
     }
 }


### PR DESCRIPTION
## Description of what I changed
I have upgraded `bytesToHex` method to use `StringBuilder` to prevent from unecessary string copying in the for loop.
**All existing tests passed.**
## Issue I worked on

https://issues.openmrs.org/browse/AC-484