### PR TITLE
AC-465: Encrypt database from the details derived from the username and password

### DIFF
--- a/openmrs-client/build.gradle
+++ b/openmrs-client/build.gradle
@@ -123,6 +123,7 @@ dependencies {
     implementation 'org.adw.library:discrete-seekbar:1.0.1'
     implementation 'com.github.PhilJay:MPAndroidChart:v3.0.2'
     implementation 'com.github.amlcurran.showcaseview:library:5.4.3'
+    implementation 'org.mindrot:jbcrypt:0.4'
     testImplementation(
             'org.mockito:mockito-core:1.10.19',
             'junit:junit:4.12',

--- a/openmrs-client/src/main/java/org/openmrs/mobile/utilities/ApplicationConstants.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/utilities/ApplicationConstants.java
@@ -28,6 +28,9 @@ public abstract class ApplicationConstants {
     public static final String LAST_SESSION_TOKEN = "last_session_id";
     public static final String LAST_LOGIN_SERVER_URL = "last_login_server_url";
     public static final String DEFAULT_OPEN_MRS_URL = "https://demo.openmrs.org/openmrs";
+    public static final String DB_PASSWORD_BCRYPT_PEPPER = "$2a$08$iUp3M1VapYpjcAXQBNX6uu";
+    public static final String DB_PASSWORD_LITERAL_PEPPER = "Open Sesame";
+    public static final int DEFAULT_BCRYPT_ROUND = 8;
 
     public abstract static class OpenMRSSharedPreferenceNames {
         public static final String SHARED_PREFERENCES_NAME = "shared_preferences";
@@ -41,6 +44,7 @@ public abstract class ApplicationConstants {
     public abstract static class UserKeys {
         public static final String USER_NAME = "username";
         public static final String PASSWORD = "password";
+        public static final String HASHED_PASSWORD = "hashedPassword";
         public static final String USER_PERSON_NAME = "userDisplay";
         public static final String USER_UUID = "userUUID";
         public static final String LOGIN = "login";

--- a/openmrs-client/src/main/res/values/strings.xml
+++ b/openmrs-client/src/main/res/values/strings.xml
@@ -30,7 +30,7 @@
     <string name="login_required">Required</string>
     <string name="req_star"><![CDATA[<font color=\'#cc0029\'> * </font>]]></string>
     <string name="warning_dialog_title">Warning</string>
-    <string name="warning_lost_data_dialog">Changing the URL or username will erase all the data. Are you sure?</string>
+    <string name="warning_lost_data_dialog">Changing the URL, username or password will erase all the data. Are you sure?</string>
     <string name="forgot_dialog_title">Unable to login?</string>
     <string name="forgot_dialog_message">Please contact the system administrator</string>
     <string name="forgot_button_ok">Dismiss</string>

--- a/openmrs-client/src/test/java/org/openmrs/mobile/test/presenters/LoginPresenterTest.java
+++ b/openmrs-client/src/test/java/org/openmrs/mobile/test/presenters/LoginPresenterTest.java
@@ -16,6 +16,7 @@ package org.openmrs.mobile.test.presenters;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.mindrot.jbcrypt.BCrypt;
 import org.mockito.Mock;
 import org.openmrs.mobile.activities.login.LoginContract;
 import org.openmrs.mobile.activities.login.LoginPresenter;
@@ -34,6 +35,7 @@ import org.openmrs.mobile.models.User;
 import org.openmrs.mobile.models.VisitType;
 import org.openmrs.mobile.net.AuthorizationManager;
 import org.openmrs.mobile.test.ACUnitTestBaseRx;
+import org.openmrs.mobile.utilities.ApplicationConstants;
 import org.openmrs.mobile.utilities.NetworkUtils;
 import org.openmrs.mobile.utilities.StringUtils;
 import org.powermock.api.mockito.PowerMockito;
@@ -190,7 +192,7 @@ public class LoginPresenterTest extends ACUnitTestBaseRx {
     }
 
     @Test
-    public void shouldLoginUserInOfflineMode_userLoggedBefore_wrongCredentials(){
+    public void shouldShowWipingDBWarningDialogUserInOfflineMode_userLoggedBefore_wrongCredentials(){
         String user = "user";
         String url = "url";
         String password = "pass";
@@ -201,8 +203,8 @@ public class LoginPresenterTest extends ACUnitTestBaseRx {
         when(openMRS.getLastLoginServerUrl()).thenReturn(url);
         presenter.login(user, password, url, url);
 
-        verify(view).showToast(anyInt(), any());
-        verify(view).hideLoadingAnimation();
+        verify(view).hideSoftKeys();
+        verify(view).showWarningDialog();
     }
 
     @Test
@@ -279,6 +281,7 @@ public class LoginPresenterTest extends ACUnitTestBaseRx {
         when(openMRS.getUsername()).thenReturn(user);
         when(openMRS.getServerUrl()).thenReturn(url);
         when(openMRS.getPassword()).thenReturn(password);
+        when(openMRS.getHashedPassword()).thenReturn(BCrypt.hashpw(password, BCrypt.gensalt(ApplicationConstants.DEFAULT_BCRYPT_ROUND)));
     }
 
     private void mockStaticMethods() {
@@ -287,6 +290,7 @@ public class LoginPresenterTest extends ACUnitTestBaseRx {
         PowerMockito.mockStatic(StringUtils.class);
         PowerMockito.mockStatic(NetworkUtils.class);
         when(openMRS.getServerUrl()).thenReturn("http://www.some_server_url.com");
+        when(openMRS.getHashedPassword()).thenReturn(ApplicationConstants.EMPTY_STRING);
         PowerMockito.when(OpenMRS.getInstance()).thenReturn(openMRS);
         PowerMockito.mockStatic(RestServiceBuilder.class);
         PowerMockito.when(RestServiceBuilder.createService(any(), any(), any())).thenReturn(restApi);


### PR DESCRIPTION
## Description of what I changed
This PR brings several changes to the code
- User's password is not stored as a plaintext (used in offline verification), but as a bcrypt hash. It makes it not possible to steal user's password from `SharedPreferences` anymore.
- SQLite database uses a peppered bcrypt hash as its password, which is derived from user's name and password. It is not stored on the device anymore, making it impossible to steal, but generated after the user enters the password.
- When the user logs in to the same account using new password, the user is warned and the DB gets wiped (because the app just breaks when user changes the pass, doesn't matter if it's online or offline and because the new password is not sufficient for generating matching key to SQLite db). This is a temporary fix to lack of handling users who have changed their passwords. The problem with these users should be addressed in future tickets/PR's/whatever (e. g. user should be asked for old password to unlock the DB locked with old pass).
- The tests have been modified to comply with new code.

**All existing tests passed.**
## Issue I worked on

https://issues.openmrs.org/browse/AC-465