### PR TITLE
AC-493: Use editor.apply() instead of editor.commit()

### DIFF
--- a/openmrs-client/src/main/java/org/openmrs/mobile/activities/dashboard/DashboardFragment.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/activities/dashboard/DashboardFragment.java
@@ -67,7 +67,7 @@ public class DashboardFragment extends ACBaseFragment<DashboardContract.Presente
 
         if (settings2.getBoolean("my_first_time", true)) {
             showOverlayTutorialOne();
-            settings2.edit().putBoolean("my_first_time", false).commit();
+            settings2.edit().putBoolean("my_first_time", false).apply();
         }
     }
 

--- a/openmrs-client/src/main/java/org/openmrs/mobile/activities/login/LoginFragment.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/activities/login/LoginFragment.java
@@ -120,7 +120,7 @@ public class LoginFragment extends ACBaseFragment<LoginContract.Presenter> imple
                 boolean syncState = prefs.getBoolean("sync", true);
                 SharedPreferences.Editor editor = PreferenceManager.getDefaultSharedPreferences(OpenMRS.getInstance()).edit();
                 editor.putBoolean("sync", !syncState);
-                editor.commit();
+                editor.apply();
                 setSyncButtonState(!syncState);
             }
         });

--- a/openmrs-client/src/main/java/org/openmrs/mobile/activities/matchingpatients/MatchingPatientsActivity.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/activities/matchingpatients/MatchingPatientsActivity.java
@@ -77,7 +77,7 @@ public class MatchingPatientsActivity extends ACBaseActivity {
         final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(OpenMRS.getInstance());
         SharedPreferences.Editor editor = prefs.edit();
         editor.putBoolean("sync", false);
-        editor.commit();
+        editor.apply();
     }
 
 }

--- a/openmrs-client/src/main/java/org/openmrs/mobile/application/OpenMRS.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/application/OpenMRS.java
@@ -89,19 +89,19 @@ public class OpenMRS extends Application {
     public void setUserLoggedOnline(boolean firstLogin) {
         SharedPreferences.Editor editor = getOpenMRSSharedPreferences().edit();
         editor.putBoolean(ApplicationConstants.UserKeys.LOGIN, firstLogin);
-        editor.commit();
+        editor.apply();
     }
 
     public void setUsername(String username) {
         SharedPreferences.Editor editor = getOpenMRSSharedPreferences().edit();
         editor.putString(ApplicationConstants.UserKeys.USER_NAME, username);
-        editor.commit();
+        editor.apply();
     }
 
     public void setPassword(String password) {
         SharedPreferences.Editor editor = getOpenMRSSharedPreferences().edit();
         editor.putString(ApplicationConstants.UserKeys.PASSWORD, password);
-        editor.commit();
+        editor.apply();
     }
 
     public void setHashedPassword(String hashedPassword) {
@@ -122,37 +122,37 @@ public class OpenMRS extends Application {
     public void setServerUrl(String serverUrl) {
         SharedPreferences.Editor editor = getOpenMRSSharedPreferences().edit();
         editor.putString(ApplicationConstants.SERVER_URL, serverUrl);
-        editor.commit();
+        editor.apply();
     }
 
     public void setLastLoginServerUrl(String url) {
         SharedPreferences.Editor editor = getOpenMRSSharedPreferences().edit();
         editor.putString(ApplicationConstants.LAST_LOGIN_SERVER_URL, url);
-        editor.commit();
+        editor.apply();
     }
 
     public void setSessionToken(String serverUrl) {
         SharedPreferences.Editor editor = getOpenMRSSharedPreferences().edit();
         editor.putString(ApplicationConstants.SESSION_TOKEN, serverUrl);
-        editor.commit();
+        editor.apply();
     }
 
     public void setAuthorizationToken(String authorization) {
         SharedPreferences.Editor editor = getOpenMRSSharedPreferences().edit();
         editor.putString(ApplicationConstants.AUTHORIZATION_TOKEN, authorization);
-        editor.commit();
+        editor.apply();
     }
 
     public void setLocation(String location) {
         SharedPreferences.Editor editor = getOpenMRSSharedPreferences().edit();
         editor.putString(ApplicationConstants.LOCATION, location);
-        editor.commit();
+        editor.apply();
     }
 
     public void setVisitTypeUUID(String visitTypeUUID) {
         SharedPreferences.Editor editor = getOpenMRSSharedPreferences().edit();
         editor.putString(ApplicationConstants.VISIT_TYPE_UUID, visitTypeUUID);
-        editor.commit();
+        editor.apply();
     }
 
     public boolean isUserLoggedOnline() {
@@ -240,7 +240,7 @@ public class OpenMRS extends Application {
     public void setDefaultFormLoadID(String xFormName, String xFormID) {
         SharedPreferences.Editor editor = getOpenMRSSharedPreferences().edit();
         editor.putString(xFormName, xFormID);
-        editor.commit();
+        editor.apply();
     }
 
     public String getDefaultFormLoadID(String xFormName) {
@@ -253,7 +253,7 @@ public class OpenMRS extends Application {
         for (Map.Entry<String, String> entry : userInformation.entrySet()) {
             editor.putString(entry.getKey(), entry.getValue());
         }
-        editor.commit();
+        editor.apply();
     }
 
     public Map<String, String> getCurrentLoggedInUserInfo() {
@@ -302,7 +302,7 @@ public class OpenMRS extends Application {
         clearCurrentLoggedInUserInfo();
         editor.remove(ApplicationConstants.UserKeys.PASSWORD);
         deleteSecretKey();
-        editor.commit();
+        editor.apply();
     }
 
 

--- a/openmrs-client/src/main/java/org/openmrs/mobile/utilities/NetworkUtils.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/utilities/NetworkUtils.java
@@ -50,7 +50,7 @@ public final class NetworkUtils {
             {
                 SharedPreferences.Editor editor = prefs.edit();
                 editor.putBoolean("sync", false);
-                editor.commit();
+                editor.apply();
                 return false;
             }
 


### PR DESCRIPTION
## Description of what I changed
This PR replaces `SharedPreferences.Editor.commit()` calls with `SharedPreferences.Editor.apply()` when the return value of `commit()` is ignored. It's better to use asynchronous version of the API to prevent from blocking UI thread. For more information, check out JIRA ticket below.

**All existing tests passed.**
## Issue I worked on

https://issues.openmrs.org/browse/AC-493