### PR TITLE
AC-483 Adding coveralls to openmrs-contrib-anroid-client repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_install:
   - yes | sdkmanager "platform-tools" "tools" "platforms;android-27" "extras;android;m2repository"
 
 after_success:
-- ./gradlew cobertura coveralls
+- ./gradlew connectedAndroidTest coveralls
 
 script:
 - ./build.sh

--- a/openmrs-client/build.gradle
+++ b/openmrs-client/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'com.android.application'
-apply plugin: 'net.saliman.cobertura'
 apply plugin: 'com.github.kt3k.coveralls'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
@@ -14,14 +13,11 @@ buildscript {
     dependencies {
         classpath 'com.github.triplet.gradle:play-publisher:1.1.5'
         classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
-        classpath "net.saliman:gradle-cobertura-plugin:2.5.4"
-        classpath "org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.8.2"
+        classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.8.2'
     }
 }
 
 apply plugin: 'com.github.triplet.play'
-
-cobertura.coverageFormats = ['html', 'xml'] // coveralls plugin depends on xml format report
 
 def version = "2.6.1-beta"
 
@@ -58,6 +54,9 @@ android {
     }
 
     buildTypes {
+        debug {
+            testCoverageEnabled true
+        }
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
@@ -151,4 +150,13 @@ play {
 
     serviceAccountEmail = System.getenv("PUBLISHER_ACCOUNT_ID")
     jsonFile = rootProject.file('google_play.json')
+}
+
+coveralls {
+    jacocoReportPath = "${buildDir}/reports/coverage/debug/report.xml"
+}
+
+tasks.coveralls {
+    dependsOn 'connectedAndroidTest'
+    onlyIf { System.env.'CI' }
 }


### PR DESCRIPTION
## Description
This PR fixes the problem that coveralls build is not present at https://coveralls.io/github/openmrs/openmrs-contrib-android-client . I used the JaCoCo plugin instead of cobertura, as described in [this tutorial](https://jeroenmols.com/blog/2015/11/13/traviscoveralls/).

## Issue I worked on
https://issues.openmrs.org/browse/AC-483

## Checklist: I completed these to help reviewers :)
- [x] My pull request only contains **ONE single commit**
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.