### PR TITLE
AC-528: Warning Dialog when back pressed

### DIFF
--- a/openmrs-client/src/main/java/org/openmrs/mobile/activities/addeditpatient/AddEditPatientActivity.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/activities/addeditpatient/AddEditPatientActivity.java
@@ -14,12 +14,15 @@
 
 package org.openmrs.mobile.activities.addeditpatient;
 
+import android.app.AlertDialog;
+import android.content.Intent;
 import android.os.Bundle;
 import android.support.v7.widget.Toolbar;
 import android.view.Menu;
 
 import org.openmrs.mobile.R;
 import org.openmrs.mobile.activities.ACBaseActivity;
+import org.openmrs.mobile.activities.dashboard.DashboardActivity;
 import org.openmrs.mobile.utilities.ApplicationConstants;
 
 import java.util.Arrays;
@@ -28,6 +31,7 @@ import java.util.List;
 public class AddEditPatientActivity extends ACBaseActivity {
 
     public AddEditPatientContract.Presenter mPresenter;
+    public AddEditPatientFragment addEditPatientFragment;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -42,7 +46,7 @@ public class AddEditPatientActivity extends ACBaseActivity {
         }
 
         // Create fragment
-        AddEditPatientFragment addEditPatientFragment =
+        addEditPatientFragment =
                 (AddEditPatientFragment) getSupportFragmentManager().findFragmentById(R.id.patientInfoContentFrame);
         if (addEditPatientFragment == null) {
             addEditPatientFragment = AddEditPatientFragment.newInstance();
@@ -78,7 +82,35 @@ public class AddEditPatientActivity extends ACBaseActivity {
     @Override
     public void onBackPressed() {
         if (!mPresenter.isRegisteringPatient()) {
+            boolean createDialog = addEditPatientFragment.areFieldsNotEmpty();
             super.onBackPressed();
+            if (createDialog) {
+                showInfoLostDialog();
+            } else {
+                if (!mPresenter.isRegisteringPatient()) {
+                    super.onBackPressed();
+                }
+            }
         }
+    }
+
+    /**
+     * The method creates a warning dialog when the user presses back button while registering a patient
+     */
+    private void showInfoLostDialog() {
+        AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(
+                this);
+        alertDialogBuilder.setTitle(R.string.dialog_title_are_you_sure);
+        // set dialog message
+        alertDialogBuilder
+                .setMessage(R.string.dialog_message_data_lost)
+                .setCancelable(false)
+                .setPositiveButton(R.string.dialog_button_stay, (dialog, id) -> dialog.cancel())
+                .setNegativeButton(R.string.dialog_button_leave, (dialog, id) -> {
+                    Intent intent = new Intent(AddEditPatientActivity.this, DashboardActivity.class);
+                    startActivity(intent);
+                });
+        AlertDialog alertDialog = alertDialogBuilder.create();
+        alertDialog.show();
     }
 }

--- a/openmrs-client/src/main/java/org/openmrs/mobile/activities/addeditpatient/AddEditPatientContract.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/activities/addeditpatient/AddEditPatientContract.java
@@ -44,6 +44,8 @@ public interface AddEditPatientContract {
         void startPatientDashbordActivity(Patient patient);
 
         void showUpgradeRegistrationModuleInfo();
+
+        boolean areFieldsNotEmpty();
     }
 
     interface Presenter extends BasePresenterContract {

--- a/openmrs-client/src/main/java/org/openmrs/mobile/activities/addeditpatient/AddEditPatientFragment.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/activities/addeditpatient/AddEditPatientFragment.java
@@ -423,6 +423,21 @@ public class AddEditPatientFragment extends ACBaseFragment<AddEditPatientContrac
         ToastUtil.notifyLong(getResources().getString(R.string.registration_core_info));
     }
 
+    @Override
+    public boolean areFieldsNotEmpty() {
+        return (!ViewUtils.isEmpty(edfname) ||
+                (!ViewUtils.isEmpty(edmname)) ||
+                (!ViewUtils.isEmpty(edlname)) ||
+                (!ViewUtils.isEmpty(eddob)) ||
+                (!ViewUtils.isEmpty(edyr)) ||
+                (!ViewUtils.isEmpty(edaddr1)) ||
+                (!ViewUtils.isEmpty(edaddr2)) ||
+                (!ViewUtils.isEmpty(edcity)) ||
+                (!ViewUtils.isEmpty(edstate)) ||
+                (!ViewUtils.isEmpty(edcountry)) ||
+                (!ViewUtils.isEmpty(edpostal)));
+    }
+
     public static AddEditPatientFragment newInstance() {
         return new AddEditPatientFragment();
     }

--- a/openmrs-client/src/main/res/values/strings.xml
+++ b/openmrs-client/src/main/res/values/strings.xml
@@ -330,4 +330,9 @@
     <!-- Syncbutton toasts -->
     <string name="disconn_server">Disconnecting from server</string>
     <string name="reconn_server">Reconnecting to server</string>
+
+    <string name="dialog_title_are_you_sure">Are you sure?</string>
+    <string name="dialog_message_data_lost">All patient information entered will be lost.</string>
+    <string name="dialog_button_stay">Stay</string>
+    <string name="dialog_button_leave">Leave</string>
 </resources>


### PR DESCRIPTION
## Description of what I changed

When the user tries to press back while registering a patient a warning dialog is presented that if he exists the activity without completing the registration, all the entered information will be lost.

![screenshot_2019-03-03-00-00-47-059_org openmrs mobile](https://user-images.githubusercontent.com/26908195/53686010-1c1b4680-3d48-11e9-862d-fb5556c46d57.png)

## Issue I worked on
JIRA Issue: https://issues.openmrs.org/browse/AC-528

## Checklist: I completed these to help reviewers :)

- [x] My pull request only contains **ONE single commit**
(the number above, next to the 'Commits' tab is 1).

- [ ] I have **added tests** to cover my changes. (If you refactored
existing code that was well tested you do not have to add tests)

- [x] All new and existing **tests passed**.

- [x] My pull request is **based on the latest changes** of the master branch.