### PR TITLE
AC-522: Prevented crashing when selecting "Take a photo" option

### DIFF
--- a/openmrs-client/src/main/java/org/openmrs/mobile/activities/addeditpatient/AddEditPatientFragment.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/activities/addeditpatient/AddEditPatientFragment.java
@@ -30,6 +30,7 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.os.Environment;
 import android.os.ParcelFileDescriptor;
+import android.os.StrictMode;
 import android.provider.MediaStore;
 import android.text.Editable;
 import android.text.TextWatcher;
@@ -624,8 +625,11 @@ public class AddEditPatientFragment extends ACBaseFragment<AddEditPatientContrac
                             @Override
                             public void onClick(DialogInterface dialog, int which) {
 
-                                if (which == 0)
+                                if (which == 0) {
+                                    StrictMode.VmPolicy.Builder builder = new StrictMode.VmPolicy.Builder();
+                                    StrictMode.setVmPolicy(builder.build());
                                     AddEditPatientFragmentPermissionsDispatcher.capturePhotoWithCheck(AddEditPatientFragment.this);
+                                }
                                 else {
                                     Intent i;
                                     if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.KITKAT)


### PR DESCRIPTION
## Description of what I changed
Some minor changes to prevent crashing of app

## Issue I worked on
JIRA Issue: https://issues.openmrs.org/browse/AC-522

Before
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/39745544/54491953-84415f00-48e8-11e9-847b-5f8ff43b0a95.gif)


Now
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/39745544/54492156-fb2b2780-48e9-11e9-8efc-7d84e4b943ec.gif)



## Checklist: I completed these to help reviewers :)
- [x] My pull request only contains **ONE single commit**
- [ ] I have **added tests** to cover my changes. (If you refactored
existing code that was well tested you do not have to add tests)
- [ ] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.