### PR TITLE
AC 558: Text gets cutoff in list item of charts fragment

### DIFF
--- a/openmrs-client/src/main/res/layout/list_vital_group.xml
+++ b/openmrs-client/src/main/res/layout/list_vital_group.xml
@@ -15,7 +15,7 @@
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="fill_parent"
-    android:layout_height="55dp"
+  android:layout_height="wrap_content"
     android:background="@drawable/card"
     android:longClickable="false"
     android:orientation="horizontal"
@@ -27,7 +27,7 @@
 
     <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+      android:layout_height="wrap_content"
         android:layout_gravity="center"
         android:layout_weight="1"
         android:gravity="center_vertical"
@@ -36,7 +36,7 @@
         <TextView
             android:id="@+id/listVisitGroupVitalName"
             android:layout_width="match_parent"
-            android:layout_height="55dp"
+          android:layout_height="wrap_content"
             android:layout_gravity="center_vertical"
             android:gravity="center_vertical|start"
             android:paddingLeft="10dp"


### PR DESCRIPTION

## Description of what I changed
**Minor UI Improvement:**
Fixed the issue of text being cutoff in charts fragment. Now the full text is being displayed.
<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->

## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first -->
<!--- Found a bug? Point us to the issue/or create one so we can reproduce it -->
<!--- Just add the issue number at the end: -->
JIRA Issue: https://issues.openmrs.org/browse/AC-558

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [x] My pull request only contains **ONE single commit**
(the number above, next to the 'Commits' tab is 1).
<!--- No? -> [read here](https://wiki.openmrs.org/display/docs/Pull+Request+Tips) on how to squash multiple commits into one -->

- [ ] I have **added tests** to cover my changes. (If you refactored
existing code that was well tested you do not have to add tests)
<!--- No? -> write tests and add them to this commit `git add . && git commit --amend`-->

- [x] All new and existing **tests passed**.
<!--- No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works. -->

- [x] My pull request is **based on the latest changes** of the master branch.
<!--- No? Unsure? -> execute command `git pull --rebase upstream master` -->

## Screenshots
**Before**
![Screenshot_20190319-172949](https://user-images.githubusercontent.com/29632425/54778871-c5fd3d00-4c3b-11e9-874c-87e18647759d.jpg)

**After**
![Screenshot_20190319-224204](https://user-images.githubusercontent.com/29632425/54778875-c990c400-4c3b-11e9-8164-fc655b40adb5.jpg)
