### PR TITLE
AC 563: Show/Hide password brings cursor of EditText to beginning

### DIFF
--- a/openmrs-client/src/main/java/org/openmrs/mobile/activities/login/LoginFragment.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/activities/login/LoginFragment.java
@@ -200,15 +200,14 @@ public class LoginFragment extends ACBaseFragment<LoginContract.Presenter> imple
             }
         });
 
-        mShowPassword.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
-            @Override
-            public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
-                if (isChecked) {
-                    mPassword.setInputType(InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD);
-                } else {
-                    mPassword.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD);
-                }
+        mShowPassword.setOnCheckedChangeListener((buttonView,isChecked) -> {
+            int cursorPosition = mPassword.getSelectionStart();
+            if (isChecked) {
+                mPassword.setInputType(InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD);
+            } else {
+                mPassword.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD);
             }
+            mPassword.setSelection(cursorPosition);
         });
     }
 


### PR DESCRIPTION
<!--- Add a pull request title above in this format -->
<!--- real example: 'AC-204 Applying MVP Model' -->
<!--- 'AC-JiraIssueNumber JiraIssueTitle' -->

## Description of what I changed
<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->
Fixes issue of cursor going to the beginning of EditText on toggling show/hide password.
Now, the cursor stays where it was before.

## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first -->
<!--- Found a bug? Point us to the issue/or create one so we can reproduce it -->
<!--- Just add the issue number at the end: -->
JIRA Issue: https://issues.openmrs.org/browse/AC-563

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [x] My pull request only contains **ONE single commit**
(the number above, next to the 'Commits' tab is 1).
<!--- No? -> [read here](https://wiki.openmrs.org/display/docs/Pull+Request+Tips) on how to squash multiple commits into one -->

- [ ] I have **added tests** to cover my changes. (If you refactored
existing code that was well tested you do not have to add tests)
<!--- No? -> write tests and add them to this commit `git add . && git commit --amend`-->

- [x] All new and existing **tests passed**.
<!--- No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works. -->

- [x] My pull request is **based on the latest changes** of the master branch.
<!--- No? Unsure? -> execute command `git pull --rebase upstream master` -->

## GIFs

**Before**
![password_cursor_before](https://user-images.githubusercontent.com/29632425/54869964-1902fb80-4dc6-11e9-90e8-07a73ea8064c.gif)


**After**
![password_cursor_after_new](https://user-images.githubusercontent.com/29632425/55634288-cf5ddc00-57db-11e9-8559-3b52bda1f5bb.gif)
