### PR TITLE
AC-571 - Application Crashes when click download concepts

### DIFF
--- a/openmrs-client/src/main/java/org/openmrs/mobile/activities/settings/SettingsFragment.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/activities/settings/SettingsFragment.java
@@ -27,6 +27,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageButton;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import org.openmrs.mobile.R;
 import org.openmrs.mobile.activities.ACBaseFragment;
@@ -36,6 +37,7 @@ import org.openmrs.mobile.utilities.ApplicationConstants;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import androidx.annotation.NonNull;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
@@ -70,13 +72,14 @@ public class SettingsFragment extends ACBaseFragment<SettingsContract.Presenter>
         settingsRecyclerView.setLayoutManager(linearLayoutManager);
 
         conceptsInDbTextView = ((TextView) root.findViewById(R.id.conceptsInDbTextView));
+
         downloadConceptsButton = ((ImageButton) root.findViewById(R.id.downloadConceptsButton));
 
         downloadConceptsButton.setOnClickListener(view -> {
             downloadConceptsButton.setEnabled(false);
             Intent startIntent = new Intent(getActivity(), ConceptDownloadService.class);
             startIntent.setAction(ApplicationConstants.ServiceActions.START_CONCEPT_DOWNLOAD_ACTION);
-            getActivity().startService(startIntent);
+            Objects.requireNonNull(getActivity()).startService(startIntent);
         });
 
         return root;
@@ -98,13 +101,16 @@ public class SettingsFragment extends ACBaseFragment<SettingsContract.Presenter>
 
     @Override
     public void setConceptsInDbText(String text) {
+        if(text.equals("0")){
+            downloadConceptsButton.setEnabled(false);
+            Toast.makeText(getActivity(), "There are no concepts in DB!",
+                    Toast.LENGTH_LONG).show();
+        }
         conceptsInDbTextView.setText(text);
     }
 
     @Override
     public void addLogsInfo(long logSize, String logFilename) {
-
-
         mListItem.add(new SettingsListItemDTO(getResources().getString(R.string.settings_logs),
                 logFilename,
                 "Size: " + logSize + "kB"));

--- a/openmrs-client/src/main/java/org/openmrs/mobile/activities/settings/SettingsFragment.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/activities/settings/SettingsFragment.java
@@ -34,6 +34,7 @@ import org.openmrs.mobile.activities.ACBaseFragment;
 import org.openmrs.mobile.models.SettingsListItemDTO;
 import org.openmrs.mobile.services.ConceptDownloadService;
 import org.openmrs.mobile.utilities.ApplicationConstants;
+import org.openmrs.mobile.utilities.ToastUtil;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -103,8 +104,9 @@ public class SettingsFragment extends ACBaseFragment<SettingsContract.Presenter>
     public void setConceptsInDbText(String text) {
         if(text.equals("0")){
             downloadConceptsButton.setEnabled(false);
-            Toast.makeText(getActivity(), "There are no concepts in DB!",
-                    Toast.LENGTH_LONG).show();
+            ToastUtil.showLongToast(getActivity(),
+                    ToastUtil.ToastType.WARNING,
+                    R.string.settings_no_concepts_toast);
         }
         conceptsInDbTextView.setText(text);
     }

--- a/openmrs-client/src/main/java/org/openmrs/mobile/services/ConceptDownloadService.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/services/ConceptDownloadService.java
@@ -58,12 +58,16 @@ public class ConceptDownloadService extends Service {
             @Override
             public void onResponse(@NonNull Call<Results<SystemSetting>> call, @NonNull Response<Results<SystemSetting>> response) {
                 if (response.isSuccessful()) {
-                    List<SystemSetting> results = response.body().getResults();
-                    if (results.size() >= 1) {
-                        String value = results.get(0).getValue();
-                        if (value != null) {
-                            maxConceptsInOneQuery = Integer.parseInt(value);
+                    List<SystemSetting> results = null;
+                    if (response.body() != null) {
+                        results = response.body().getResults();
+                        if (results.size() >= 1) {
+                            String value = results.get(0).getValue();
+                            if (value != null) {
+                                maxConceptsInOneQuery = Integer.parseInt(value);
+                            }
                         }
+
                     }
                 }
                 downloadConcepts(0);
@@ -107,20 +111,24 @@ public class ConceptDownloadService extends Service {
             public void onResponse(@NonNull Call<Results<Concept>> call, @NonNull Response<Results<Concept>> response) {
                 if (response.isSuccessful()) {
                     ConceptDAO conceptDAO = new ConceptDAO();
-                    for (Concept concept : response.body().getResults()) {
-                        conceptDAO.saveOrUpdate(concept);
-                        downloadedConcepts++;
+                    if (response.body() != null) {
+                        for (Concept concept : response.body().getResults()) {
+                            conceptDAO.saveOrUpdate(concept);
+                            downloadedConcepts++;
+                        }
                     }
 
                     showNotification(downloadedConcepts);
                     sendProgressBroadcast();
 
                     boolean isNextPage = false;
-                    for (Link link : response.body().getLinks()) {
-                        if ("next".equals(link.getRel())) {
-                            isNextPage = true;
-                            downloadConcepts(startIndex + maxConceptsInOneQuery);
-                            break;
+                    if (response.body() != null) {
+                        for (Link link : response.body().getLinks()) {
+                            if ("next".equals(link.getRel())) {
+                                isNextPage = true;
+                                downloadConcepts(startIndex + maxConceptsInOneQuery);
+                                break;
+                            }
                         }
                     }
                     if (!isNextPage) {

--- a/openmrs-client/src/main/java/org/openmrs/mobile/services/ConceptDownloadService.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/services/ConceptDownloadService.java
@@ -67,7 +67,6 @@ public class ConceptDownloadService extends Service {
                                 maxConceptsInOneQuery = Integer.parseInt(value);
                             }
                         }
-
                     }
                 }
                 downloadConcepts(0);

--- a/openmrs-client/src/main/res/values/strings.xml
+++ b/openmrs-client/src/main/res/values/strings.xml
@@ -154,6 +154,7 @@
     <string name="settings_application_info">Application Info</string>
     <string name="settings_concepts_info">Concepts Info</string>
     <string name="settings_concepts_in_db">Concepts in DB:</string>
+    <string name="settings_no_concepts_toast">There are no concepts in DB!</string>
 
     <!-- FindPatients activity -->
     <string name="action_find_patients">Find Patients</string>


### PR DESCRIPTION
## Description of what I changed
Added a condition to check whether the concepts in DB are 0 and disabled the user from clicking the Download Button if this condition is true and a toast will be displayed on page load informing the user of this. Further, null checks were introduced to ConceptDownloadService class.

## Issue I worked on
This is a critical bug in the Android Application
JIRA Issue: https://issues.openmrs.org/browse/AC-571

## Checklist: I completed these to help reviewers :)
- [x] My pull request only contains **ONE single commit**

- [ ] I have **added tests** to cover my changes. (Only existing code was refactored)

- [x] All new and existing **tests passed**.

- [x] My pull request is **based on the latest changes** of the master branch.
