### PR TITLE
 GCI-340 Android Client: Fix this Static field leak

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.1'
+        classpath 'com.android.tools.build:gradle:3.5.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.dicedmelon.gradle:jacoco-android:0.1.4'
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue May 28 17:27:49 MSK 2019
+#Tue Dec 03 19:44:44 EST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dist
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip

--- a/openmrs-client/src/main/java/org/openmrs/mobile/activities/patientdashboard/PatientDashboardActivity.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/activities/patientdashboard/PatientDashboardActivity.java
@@ -27,6 +27,9 @@ import android.view.View;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 
+import androidx.fragment.app.Fragment;
+import androidx.viewpager.widget.ViewPager;
+
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import com.google.android.material.tabs.TabLayout;
 
@@ -47,9 +50,6 @@ import org.openmrs.mobile.utilities.ApplicationConstants;
 import org.openmrs.mobile.utilities.ImageUtils;
 import org.openmrs.mobile.utilities.TabUtil;
 
-import androidx.fragment.app.Fragment;
-import androidx.viewpager.widget.ViewPager;
-
 public class PatientDashboardActivity extends ACBaseActivity {
 
     private String mId;
@@ -58,7 +58,7 @@ public class PatientDashboardActivity extends ACBaseActivity {
 
     static boolean isActionFABOpen = false;
     public static FloatingActionButton additionalActionsFAB, updateFAB, deleteFAB;
-    public static LinearLayout deleteFabLayout, updateFabLayout;
+    public LinearLayout deleteFabLayout, updateFabLayout;
     public static Resources resources;
 
     @Override
@@ -164,7 +164,7 @@ public class PatientDashboardActivity extends ACBaseActivity {
         updateFAB.setOnClickListener(v -> startPatientUpdateActivity(mPresenter.getPatientId()));
     }
 
-    public static void showFABMenu() {
+    public void showFABMenu() {
         isActionFABOpen = true;
         deleteFabLayout.setVisibility(View.VISIBLE);
         updateFabLayout.setVisibility(View.VISIBLE);
@@ -172,7 +172,7 @@ public class PatientDashboardActivity extends ACBaseActivity {
         updateFabLayout.animate().translationY(-resources.getDimension(R.dimen.custom_fab_bottom_margin_105));
     }
 
-    public static void closeFABMenu() {
+    public void closeFABMenu() {
         isActionFABOpen = false;
         deleteFabLayout.animate().translationY(0);
         updateFabLayout.animate().translationY(0);
@@ -193,7 +193,7 @@ public class PatientDashboardActivity extends ACBaseActivity {
      * @param hide To hide the FAB menu depending on the Fragment visible
      */
     @SuppressLint("RestrictedApi")
-    public static void hideFABs(boolean hide) {
+    public void hideFABs(boolean hide) {
         closeFABMenu();
         if (hide) {
             additionalActionsFAB.setVisibility(View.GONE);

--- a/openmrs-client/src/main/java/org/openmrs/mobile/activities/patientdashboard/charts/PatientChartsFragment.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/activities/patientdashboard/charts/PatientChartsFragment.java
@@ -51,6 +51,7 @@ public class PatientChartsFragment extends PatientDashboardFragment implements P
     private TextView mEmptyListView;
     private JSONObject observationList;
     private PatientChartsListAdapter chartsListAdapter;
+    private PatientDashboardActivity mPatientDashboardActivit;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -184,7 +185,7 @@ public class PatientChartsFragment extends PatientDashboardFragment implements P
         super.setUserVisibleHint(isVisibleToUser);
         if (isVisibleToUser) {
             try {
-                PatientDashboardActivity.hideFABs(true);
+                mPatientDashboardActivit.hideFABs(true);
             } catch (Exception e) {
                 e.printStackTrace();
             }

--- a/openmrs-client/src/main/java/org/openmrs/mobile/activities/patientdashboard/details/PatientDetailsFragment.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/activities/patientdashboard/details/PatientDetailsFragment.java
@@ -15,7 +15,6 @@
 package org.openmrs.mobile.activities.patientdashboard.details;
 
 import android.content.Context;
-import android.content.Intent;
 import android.graphics.Bitmap;
 import android.os.Bundle;
 import android.view.LayoutInflater;
@@ -32,12 +31,10 @@ import androidx.annotation.Nullable;
 
 import org.openmrs.mobile.R;
 import org.openmrs.mobile.activities.ACBaseActivity;
-import org.openmrs.mobile.activities.addeditpatient.AddEditPatientActivity;
 import org.openmrs.mobile.activities.patientdashboard.PatientDashboardActivity;
 import org.openmrs.mobile.activities.patientdashboard.PatientDashboardContract;
 import org.openmrs.mobile.activities.patientdashboard.PatientDashboardFragment;
 import org.openmrs.mobile.models.Patient;
-import org.openmrs.mobile.utilities.ApplicationConstants;
 import org.openmrs.mobile.utilities.DateUtils;
 import org.openmrs.mobile.utilities.FontsUtil;
 import org.openmrs.mobile.utilities.ImageUtils;
@@ -171,7 +168,7 @@ public class PatientDetailsFragment extends PatientDashboardFragment implements 
         super.setUserVisibleHint(isVisibleToUser);
         if (isVisibleToUser) {
             try {
-                PatientDashboardActivity.hideFABs(false);
+                mPatientDashboardActivity.hideFABs(false);
             } catch (Exception e) {
                 e.printStackTrace();
             }

--- a/openmrs-client/src/main/java/org/openmrs/mobile/activities/patientdashboard/diagnosis/PatientDiagnosisFragment.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/activities/patientdashboard/diagnosis/PatientDiagnosisFragment.java
@@ -38,6 +38,7 @@ import java.util.List;
 public class PatientDiagnosisFragment extends PatientDashboardFragment implements PatientDashboardContract.ViewPatientDiagnosis {
 
     private ListView mDiagnosisList;
+    private PatientDashboardActivity mPatientDashboardActivit;
 
     public static PatientDiagnosisFragment newInstance() {
         return new PatientDiagnosisFragment();
@@ -77,7 +78,7 @@ public class PatientDiagnosisFragment extends PatientDashboardFragment implement
         super.setUserVisibleHint(isVisibleToUser);
         if (isVisibleToUser) {
             try {
-                PatientDashboardActivity.hideFABs(true);
+                mPatientDashboardActivit.hideFABs(true);
             } catch (Exception e) {
                 e.printStackTrace();
             }

--- a/openmrs-client/src/main/java/org/openmrs/mobile/activities/patientdashboard/visits/PatientVisitsFragment.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/activities/patientdashboard/visits/PatientVisitsFragment.java
@@ -44,7 +44,7 @@ public class PatientVisitsFragment extends PatientDashboardFragment implements P
 
     private RecyclerView visitRecyclerView;
     private TextView emptyList;
-
+    private PatientDashboardActivity mPatientDashboardActivit;
     public static final int REQUEST_CODE_FOR_VISIT = 1;
 
     public static PatientVisitsFragment newInstance() {
@@ -154,7 +154,7 @@ public class PatientVisitsFragment extends PatientDashboardFragment implements P
         super.setUserVisibleHint(isVisibleToUser);
         if (isVisibleToUser) {
             try {
-                PatientDashboardActivity.hideFABs(true);
+                mPatientDashboardActivit.hideFABs(true);
             } catch (Exception e) {
                 e.printStackTrace();
             }

--- a/openmrs-client/src/main/java/org/openmrs/mobile/activities/patientdashboard/vitals/PatientVitalsFragment.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/activities/patientdashboard/vitals/PatientVitalsFragment.java
@@ -49,7 +49,7 @@ public class PatientVitalsFragment extends PatientDashboardFragment implements P
     private LinearLayout mFormHeader;
     private TextView mEmptyList;
     private TextView mLastVitalsDate;
-
+    private PatientDashboardActivity patientsVitals;
     private LayoutInflater mInflater;
 
     @Override
@@ -135,7 +135,7 @@ public class PatientVitalsFragment extends PatientDashboardFragment implements P
         super.setUserVisibleHint(isVisibleToUser);
         if (isVisibleToUser) {
             try {
-                PatientDashboardActivity.hideFABs(true);
+                patientsVitals.hideFABs(true);
             } catch (Exception e) {
                 e.printStackTrace();
             }


### PR DESCRIPTION

## Description of what I changed
In order to bypass the the static memory leak, I created instance variables in each of the other classes that used LinearLayouts and used that to access the methods from the PatientsDashboardActivity class.

## Issue I worked on
../../src/main/java/org/openmrs/mobile/activities/patientdashboard/PatientDashboardActivity.java:61: Do not place Android context classes in static fields; this is a memory leak

## Checklist: I completed these to help reviewers :)
- [x ] My pull request only contains **ONE single commit**
(the number above, next to the 'Commits' tab is 1).
<!--- No? -> [read here](https://wiki.openmrs.org/display/docs/Pull+Request+Tips) on how to squash multiple commits into one -->

- [ x] All new and existing **tests passed**.
<!--- No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works. -->

- [ x] My pull request is **based on the latest changes** of the master branch.
<!--- No? Unsure? -> execute command `git pull --rebase upstream master` -->