### PR TITLE
AC-530 The form edit button in Vitals page is not working

### DIFF
--- a/openmrs-client/src/main/java/org/openmrs/mobile/activities/login/LoginFragment.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/activities/login/LoginFragment.java
@@ -359,6 +359,8 @@ public class LoginFragment extends ACBaseFragment<LoginContract.Presenter> imple
         Intent intent = new Intent(mOpenMRS.getApplicationContext(), DashboardActivity.class);
         intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         mOpenMRS.getApplicationContext().startActivity(intent);
+        Intent formListServiceIntent = new Intent(mOpenMRS.getApplicationContext(), FormListService.class);
+        mOpenMRS.getApplicationContext().startService(formListServiceIntent);
         mPresenter.saveLocationsToDatabase(mLocationsList, mDropdownLocation.getSelectedItem().toString());
     }
 

--- a/openmrs-client/src/test/java/org/openmrs/mobile/test/presenters/LoginPresenterTest.java
+++ b/openmrs-client/src/test/java/org/openmrs/mobile/test/presenters/LoginPresenterTest.java
@@ -14,12 +14,15 @@
 
 package org.openmrs.mobile.test.presenters;
 
+import android.content.Context;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.mindrot.jbcrypt.BCrypt;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.openmrs.mobile.activities.login.LoginContract;
+import org.openmrs.mobile.activities.login.LoginFragment;
 import org.openmrs.mobile.activities.login.LoginPresenter;
 import org.openmrs.mobile.api.RestApi;
 import org.openmrs.mobile.api.RestServiceBuilder;
@@ -52,6 +55,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @PrepareForTest({OpenMRS.class, NetworkUtils.class, LocationDAO.class, RestServiceBuilder.class,
@@ -263,6 +267,20 @@ public class LoginPresenterTest extends ACUnitTestBaseRx {
         verify(view).hideLoadingAnimation();
     }
 
+    @Test
+    public void shouldStartFormListServiceWhenAuthenticated(){
+        Context context = PowerMockito.mock(Context.class);
+        PowerMockito.mockStatic(OpenMRS.class);
+        PowerMockito.when(OpenMRS.getInstance()).thenReturn(openMRS);
+        PowerMockito.when(openMRS.getApplicationContext()).thenReturn(context);
+        LoginFragment loginFragment = LoginFragment.newInstance();
+        try {
+            loginFragment.userAuthenticated();
+        } catch (NullPointerException ignored) {}
+
+        verify(openMRS.getApplicationContext(), times(1)).startService(any());
+    }
+
     private void mockNetworkConnection(boolean isNetwork) {
         PowerMockito.when(NetworkUtils.hasNetwork()).thenReturn(isNetwork);
     }
@@ -295,5 +313,4 @@ public class LoginPresenterTest extends ACUnitTestBaseRx {
         PowerMockito.mockStatic(RestServiceBuilder.class);
         PowerMockito.when(RestServiceBuilder.createService(any(), any(), any())).thenReturn(restApi);
     }
-
 }


### PR DESCRIPTION
<!--- Add a pull request title above in this format -->
<!--- real example: 'AC-204 Applying MVP Model' -->
<!--- 'AC-JiraIssueNumber JiraIssueTitle' -->

## Description of what I changed
<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->
Upon investigation, I have discovered that when signing in to OpenMRS AC for the first time, `FormListService` is not called due to the user not being logged in. After the user authenticates successfully, they cannot use any forms, since they have not been downloaded. I have fixed this by calling `FormListService` upon user authentication in `LoginFragment`.

## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first -->
<!--- Found a bug? Point us to the issue/or create one so we can reproduce it -->
<!--- Just add the issue number at the end: -->
JIRA Issue: https://issues.openmrs.org/browse/AC-530

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [x] My pull request only contains **ONE single commit**
(the number above, next to the 'Commits' tab is 1).
<!--- No? -> [read here](https://wiki.openmrs.org/display/docs/Pull+Request+Tips) on how to squash multiple commits into one -->

- [ ] I have **added tests** to cover my changes. (If you refactored
existing code that was well tested you do not have to add tests)
<!--- No? -> write tests and add them to this commit `git add . && git commit --amend`-->

- [x] All new and existing **tests passed**.
<!--- No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works. -->

- [x] My pull request is **based on the latest changes** of the master branch.
<!--- No? Unsure? -> execute command `git pull --rebase upstream master` -->