### PR TITLE
AC-670 UI fixes in Register Patient Activity

### DIFF
--- a/openmrs-client/src/main/java/org/openmrs/mobile/activities/addeditpatient/AddEditPatientActivity.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/activities/addeditpatient/AddEditPatientActivity.java
@@ -106,7 +106,7 @@ public class AddEditPatientActivity extends ACBaseActivity {
         alertDialogBuilder
                 .setMessage(R.string.dialog_message_data_lost)
                 .setCancelable(false)
-                .setPositiveButton(R.string.dialog_button_stay, (dialog, id) -> dialog.cancel())
+                .setNeutralButton(R.string.dialog_button_stay, (dialog, id) -> dialog.cancel())
                 .setNegativeButton(R.string.dialog_button_leave, (dialog, id) -> {
                     // Finish the activity
                     super.onBackPressed();

--- a/openmrs-client/src/main/res/layout/fragment_patient_info.xml
+++ b/openmrs-client/src/main/res/layout/fragment_patient_info.xml
@@ -494,7 +494,6 @@
                             android:maxLines="1"
                             android:textSize="14sp" />
                     </com.google.android.material.textfield.TextInputLayout>
-
                     <LinearLayout
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
@@ -506,49 +505,60 @@
                         android:orientation="horizontal"
                         android:weightSum="2">
 
-                        <com.google.android.material.textfield.TextInputLayout
-                            android:id="@+id/textInputLayoutCountry"
-                            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+                        <LinearLayout
                             android:layout_width="0dp"
                             android:layout_height="match_parent"
+                            android:layout_gravity="center"
                             android:layout_weight="1"
-                            android:gravity="center"
-                            app:errorEnabled="true">
+                            android:orientation="vertical">
 
                             <com.hbb20.CountryCodePicker
                                 android:id="@+id/ccp"
                                 android:layout_width="match_parent"
                                 android:layout_height="match_parent"
-                                android:layout_marginTop="-14dp"
+                                android:gravity="center"
                                 app:ccpDialog_textColor="?attr/colorControlNormal"
                                 app:ccp_showFullName="true"
                                 app:ccp_showNameCode="false"
                                 app:ccp_showPhoneCode="false" />
-                        </com.google.android.material.textfield.TextInputLayout>
+                        </LinearLayout>
 
-                        <com.google.android.material.textfield.TextInputLayout
-                            android:id="@+id/textInputLayoutState"
-                            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+                        <LinearLayout
                             android:layout_width="0dp"
                             android:layout_height="wrap_content"
-                            android:layout_marginStart="8dp"
-                            android:layout_marginLeft="8dp"
-                            android:layout_weight="1">
+                            android:layout_gravity="center"
+                            android:layout_weight="1"
+                            android:orientation="vertical">
 
-                            <AutoCompleteTextView
-                                android:id="@+id/state"
+                            <com.google.android.material.textfield.TextInputLayout
+                                android:id="@+id/textInputLayoutState"
+                                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
                                 android:layout_width="match_parent"
-                                android:layout_height="48dp"
-                                android:layout_marginStart="4dp"
-                                android:layout_marginLeft="4dp"
-                                android:focusable="true"
-                                android:hint="@string/patient_state_label"
-                                android:imeOptions="actionNext"
-                                android:inputType="text"
-                                android:maxLines="1"
-                                android:textSize="14sp" />
-                        </com.google.android.material.textfield.TextInputLayout>
+                                android:layout_height="match_parent"
+                                android:layout_marginEnd="4dp"
+                                android:layout_marginRight="4dp">
+
+                                <AutoCompleteTextView
+                                    android:id="@+id/state"
+                                    android:layout_width="match_parent"
+                                    android:layout_height="48dp"
+                                    android:layout_marginStart="4dp"
+                                    android:layout_marginLeft="4dp"
+                                    android:focusable="true"
+                                    android:paddingLeft="12dp"
+                                    android:hint="@string/patient_state_label"
+                                    android:imeOptions="actionNext"
+                                    android:inputType="text"
+                                    android:maxLines="1"
+                                    android:textSize="14sp"
+                                    android:paddingStart="12dp" />
+
+                            </com.google.android.material.textfield.TextInputLayout>
+
+                        </LinearLayout>
+
                     </LinearLayout>
+
 
                     <LinearLayout
                         android:layout_width="match_parent"


### PR DESCRIPTION
<!--- Add a pull request title above in this format -->
<!--- real example: 'AC-204 Applying MVP Model' -->
<!--- 'AC-JiraIssueNumber JiraIssueTitle' -->

## Description of what I changed
 In XML fragment_patient_info country picker & state autocomplete aligned 
In AddEditPatientActivity alert dialog box buttons alignment corrected Positive Button -> Neutral Button
<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->

## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first -->
<!--- Found a bug? Point us to the issue/or create one so we can reproduce it -->
<!--- Just add the issue number at the end: -->
JIRA Issue: https://issues.openmrs.org/browse/AC-670

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [x] My pull request only contains **ONE single commit**
(the number above, next to the 'Commits' tab is 1).
<!--- No? -> [read here](https://wiki.openmrs.org/display/docs/Pull+Request+Tips) on how to squash multiple commits into one -->

- [x] I have **added tests** to cover my changes. (If you refactored
existing code that was well tested you do not have to add tests)
<!--- No? -> write tests and add them to this commit `git add . && git commit --amend`-->

- [x] All new and existing **tests passed**.
<!--- No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works. -->

- [x] My pull request is **based on the latest changes** of the master branch.
<!--- No? Unsure? -> execute command `git pull --rebase upstream master` -->

## Screenshots
![1](https://user-images.githubusercontent.com/36266597/73081754-2f9a4780-3eee-11ea-9c22-08512da0362c.jpeg)
![2](https://user-images.githubusercontent.com/36266597/73081755-3032de00-3eee-11ea-8942-d1fd7eabd103.jpeg)
