### PR TITLE
AC-768: Added adjustResize to avoid soft keyboard to block snackbar messages

### DIFF
--- a/openmrs-client/src/main/AndroidManifest.xml
+++ b/openmrs-client/src/main/AndroidManifest.xml
@@ -105,7 +105,7 @@
             android:launchMode="singleTop"
             android:noHistory="true"
             android:theme="@style/NoActionBarTheme"
-            android:windowSoftInputMode="adjustPan"/>
+            android:windowSoftInputMode="adjustResize"/>
         <activity
             android:name=".activities.settings.SettingsActivity"
             android:configChanges="locale|orientation"


### PR DESCRIPTION
## Description of what I changed
Added adjustResize instead of adjustPan in windowSoftInputMode attribute for LoginActivity in manifest file.

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/56463684/82596824-9cd09780-9bc5-11ea-9d31-e70801a23b38.gif)

## Issue I worked on
JIRA Issue: https://issues.openmrs.org/browse/AC-768

## Checklist: I completed these to help reviewers :)
- [x] My pull request only contains **ONE single commit**
(the number above, next to the 'Commits' tab is 1).

- [ ] I have **added tests** to cover my changes. (If you refactored
existing code that was well tested you do not have to add tests)

- [x] All new and existing **tests passed**.

- [x] My pull request is **based on the latest changes** of the master branch.
