### PR TITLE
AC-859 Displaying error if all address fields are empty

### DIFF
--- a/openmrs-client/src/main/java/org/openmrs/mobile/activities/addeditpatient/AddEditPatientFragment.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/activities/addeditpatient/AddEditPatientFragment.java
@@ -188,6 +188,12 @@ public class AddEditPatientFragment extends ACBaseFragment<AddEditPatientContrac
         } else {
             this.binding.gendererror.setVisibility(View.GONE);
         }
+
+        if(addressError) {
+            this.binding.addressError.setVisibility(View.VISIBLE);
+        } else {
+            this.binding.addressError.setVisibility(View.GONE);
+        }
     }
 
     @Override


### PR DESCRIPTION
### **Description of what I changed-**

https://user-images.githubusercontent.com/56927750/104127924-ca539680-538a-11eb-93e4-d01f57e30752.jpeg

Earlier if all the address fields were empty and someone tried to register patient, then no error message was being displayed. In this pull request I have corrected this and now if all the address fields are empty an error message is being displayed.

### **Issue I worked on -**
JIRA Issue: https://issues.openmrs.org/projects/AC/issues/AC-859

### **Checklist: I completed these to help reviewers :)**

- [x] My pull request only contains **ONE single commit**
(the number above, next to the 'Commits' tab is 1).

- [ ] I have **added tests** to cover my changes. (If you refactored
existing code that was well tested you do not have to add tests)

- [x] All new and existing **tests passed**.

- [x] My pull request is **based on the latest changes** of the master branch.