### PR TITLE
AC-862 Corrected mail recipient in the contact us page

### DIFF
--- a/openmrs-client/src/main/java/org/openmrs/mobile/activities/community/contact/ContactUsActivity.kt
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/activities/community/contact/ContactUsActivity.kt
@@ -43,7 +43,7 @@ class ContactUsActivity : ACBaseActivity(), ContactUsContract.View {
 
         binding.emailLayout.setOnClickListener {
             val sendMailIntent = Intent(Intent.ACTION_SENDTO)
-            val mailTo = "mailto:" + binding.contactEmailText.text.toString()
+            val mailTo = "mailto:" + binding.contactEmailLink.text.toString()
             sendMailIntent.data = Uri.parse(mailTo)
             try {
                 startActivity(sendMailIntent)


### PR DESCRIPTION
## Description of what I changed
In Contact Us activity on tapping Email Us, the user is redirected to Gmail App but the email address to whom we have to send the mail was not the company's mail id but instead the text "Email us". Now it has been corrected and the correct mail address has been added.

## Issue I worked on
JIRA Issue: https://issues.openmrs.org/browse/AC-862

## Checklist: I completed these to help reviewers :)
- [x] My pull request only contains **ONE single commit**
(the number above, next to the 'Commits' tab is 1).

- [ ] I have **added tests** to cover my changes. (If you refactored
existing code that was well tested you do not have to add tests)

- [x] All new and existing **tests passed**.

- [x] My pull request is **based on the latest changes** of the master branch.