### PR TITLE
AC-869 Replaced language codes with their full names in Settings Activity.

### DIFF
--- a/openmrs-client/src/main/java/org/openmrs/mobile/activities/settings/SettingsFragment.kt
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/activities/settings/SettingsFragment.kt
@@ -178,7 +178,7 @@ class SettingsFragment : ACBaseFragment<SettingsContract.Presenter>(), SettingsC
             languageSpinner.setSelection(mPresenter?.languagePosition ?: 0)
             languageSpinner.onItemSelectedListener = object : OnItemSelectedListener {
                 override fun onItemSelected(parent: AdapterView<*>?, view: View?, position: Int, id: Long) {
-                    mPresenter?.language = languageSpinner.selectedItem.toString()
+                    mPresenter?.language = ApplicationConstants.OpenMRSlanguage.LANGUAGE_CODE[position]
                 }
 
                 override fun onNothingSelected(parent: AdapterView<*>?) {}

--- a/openmrs-client/src/main/java/org/openmrs/mobile/utilities/ApplicationConstants.kt
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/utilities/ApplicationConstants.kt
@@ -156,7 +156,8 @@ object ApplicationConstants {
 
     object OpenMRSlanguage {
         const val KEY_LANGUAGE_MODE = "key_language_mode"
-        val LANGUAGE_LIST = arrayOf("en", "hi")
+        val LANGUAGE_LIST = arrayOf("English", "हिन्दी")
+        val LANGUAGE_CODE = arrayOf("en", "hi")
     }
 
     object ShowCaseViewConstants {


### PR DESCRIPTION
## Description of what I changed
In the settings activity initially language codes were used. They are now replaced with the full language names.

## Issue I worked on
JIRA Issue: https://issues.openmrs.org/browse/AC-869

## Checklist: I completed these to help reviewers :)

- [x] My pull request only contains **ONE single commit**
(the number above, next to the 'Commits' tab is 1).

- [ ] I have **added tests** to cover my changes. (If you refactored
existing code that was well tested you do not have to add tests)

- [x] All new and existing **tests passed**.

- [x] My pull request is **based on the latest changes** of the master branch.