### PR TITLE
AC-961 Changed color of buttons of Alert Dialog

### DIFF
--- a/openmrs-client/src/main/java/org/openmrs/mobile/activities/ACBaseActivity.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/activities/ACBaseActivity.java
@@ -420,6 +420,9 @@ public abstract class ACBaseActivity extends AppCompatActivity {
                 });
 
         alertDialog = alertDialogBuilder.create();
+        alertDialog.getButton(AlertDialog.BUTTON_POSITIVE).setTextColor(getResources().getColor(R.color.neutral_green));
+        alertDialog.getButton(AlertDialog.BUTTON_NEGATIVE).setTextColor(getResources().getColor(R.color.neutral_green));
+        alertDialog.getButton(AlertDialog.BUTTON_NEUTRAL).setTextColor(getResources().getColor(R.color.neutral_green));
         alertDialog.show();
     }
 

--- a/openmrs-client/src/main/java/org/openmrs/mobile/activities/ACBaseActivity.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/activities/ACBaseActivity.java
@@ -418,11 +418,12 @@ public abstract class ACBaseActivity extends AppCompatActivity {
 
                     startActivity(Intent.createChooser(email, getString(R.string.choose_a_email_client)));
                 });
-
         alertDialog = alertDialogBuilder.create();
-        alertDialog.getButton(AlertDialog.BUTTON_POSITIVE).setTextColor(getResources().getColor(R.color.neutral_green));
-        alertDialog.getButton(AlertDialog.BUTTON_NEGATIVE).setTextColor(getResources().getColor(R.color.neutral_green));
-        alertDialog.getButton(AlertDialog.BUTTON_NEUTRAL).setTextColor(getResources().getColor(R.color.neutral_green));
+        alertDialog.setOnShowListener(dialogInterface -> {
+            alertDialog.getButton(AlertDialog.BUTTON_POSITIVE).setTextColor(getResources().getColor(R.color.neutral_green));
+            alertDialog.getButton(AlertDialog.BUTTON_NEGATIVE).setTextColor(getResources().getColor(R.color.neutral_green));
+            alertDialog.getButton(AlertDialog.BUTTON_NEUTRAL).setTextColor(getResources().getColor(R.color.neutral_green));
+        });
         alertDialog.show();
     }
 

--- a/openmrs-client/src/main/java/org/openmrs/mobile/activities/ACBaseActivity.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/activities/ACBaseActivity.java
@@ -398,7 +398,7 @@ public abstract class ACBaseActivity extends AppCompatActivity {
 
     public void showAppCrashDialog(String error) {
         AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(
-                this);
+                this,R.style.AlertDialogTheme);
         alertDialogBuilder.setTitle(R.string.crash_dialog_title);
         // set dialog message
         alertDialogBuilder
@@ -419,11 +419,6 @@ public abstract class ACBaseActivity extends AppCompatActivity {
                     startActivity(Intent.createChooser(email, getString(R.string.choose_a_email_client)));
                 });
         alertDialog = alertDialogBuilder.create();
-        alertDialog.setOnShowListener(dialogInterface -> {
-            alertDialog.getButton(AlertDialog.BUTTON_POSITIVE).setTextColor(getResources().getColor(R.color.neutral_green));
-            alertDialog.getButton(AlertDialog.BUTTON_NEGATIVE).setTextColor(getResources().getColor(R.color.neutral_green));
-            alertDialog.getButton(AlertDialog.BUTTON_NEUTRAL).setTextColor(getResources().getColor(R.color.neutral_green));
-        });
         alertDialog.show();
     }
 

--- a/openmrs-client/src/main/java/org/openmrs/mobile/activities/addeditallergy/AddEditAllergyFragment.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/activities/addeditallergy/AddEditAllergyFragment.java
@@ -216,8 +216,10 @@ public class AddEditAllergyFragment extends ACBaseFragment<AddEditAllergyContrac
                     })
                     .setNegativeButton(R.string.dialog_button_cancel, (dialog, id) -> alertDialog.cancel());
             alertDialog = alertDialogBuilder.create();
-            alertDialog.getButton(AlertDialog.BUTTON_POSITIVE).setTextColor(getResources().getColor(R.color.neutral_green));
-            alertDialog.getButton(AlertDialog.BUTTON_NEGATIVE).setTextColor(getResources().getColor(R.color.neutral_green));
+            alertDialog.setOnShowListener(dialogInterface -> {
+                alertDialog.getButton(AlertDialog.BUTTON_POSITIVE).setTextColor(getResources().getColor(R.color.neutral_green));
+                alertDialog.getButton(AlertDialog.BUTTON_NEGATIVE).setTextColor(getResources().getColor(R.color.neutral_green));
+            });
             alertDialog.show();
         }
     }

--- a/openmrs-client/src/main/java/org/openmrs/mobile/activities/addeditallergy/AddEditAllergyFragment.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/activities/addeditallergy/AddEditAllergyFragment.java
@@ -200,7 +200,7 @@ public class AddEditAllergyFragment extends ACBaseFragment<AddEditAllergyContrac
         if (null == allergyCreate.getAllergen()) {
             ToastUtil.error(getString(R.string.warning_select_allergen));
         } else {
-            AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(getContext());
+            AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(getContext(),R.style.AlertDialogTheme);
             alertDialogBuilder.setTitle(getString(R.string.create_allergy_title));
             alertDialogBuilder
                     .setMessage(R.string.create_allergy_description)
@@ -216,10 +216,6 @@ public class AddEditAllergyFragment extends ACBaseFragment<AddEditAllergyContrac
                     })
                     .setNegativeButton(R.string.dialog_button_cancel, (dialog, id) -> alertDialog.cancel());
             alertDialog = alertDialogBuilder.create();
-            alertDialog.setOnShowListener(dialogInterface -> {
-                alertDialog.getButton(AlertDialog.BUTTON_POSITIVE).setTextColor(getResources().getColor(R.color.neutral_green));
-                alertDialog.getButton(AlertDialog.BUTTON_NEGATIVE).setTextColor(getResources().getColor(R.color.neutral_green));
-            });
             alertDialog.show();
         }
     }

--- a/openmrs-client/src/main/java/org/openmrs/mobile/activities/addeditallergy/AddEditAllergyFragment.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/activities/addeditallergy/AddEditAllergyFragment.java
@@ -216,6 +216,8 @@ public class AddEditAllergyFragment extends ACBaseFragment<AddEditAllergyContrac
                     })
                     .setNegativeButton(R.string.dialog_button_cancel, (dialog, id) -> alertDialog.cancel());
             alertDialog = alertDialogBuilder.create();
+            alertDialog.getButton(AlertDialog.BUTTON_POSITIVE).setTextColor(getResources().getColor(R.color.neutral_green));
+            alertDialog.getButton(AlertDialog.BUTTON_NEGATIVE).setTextColor(getResources().getColor(R.color.neutral_green));
             alertDialog.show();
         }
     }

--- a/openmrs-client/src/main/java/org/openmrs/mobile/activities/addeditpatient/AddEditPatientActivity.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/activities/addeditpatient/AddEditPatientActivity.java
@@ -141,6 +141,8 @@ public class AddEditPatientActivity extends ACBaseActivity {
                 finish();
             });
         alertDialog = alertDialogBuilder.create();
+        alertDialog.getButton(AlertDialog.BUTTON_POSITIVE).setTextColor(getResources().getColor(R.color.neutral_green));
+        alertDialog.getButton(AlertDialog.BUTTON_NEGATIVE).setTextColor(getResources().getColor(R.color.neutral_green));
         alertDialog.show();
     }
 

--- a/openmrs-client/src/main/java/org/openmrs/mobile/activities/addeditpatient/AddEditPatientActivity.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/activities/addeditpatient/AddEditPatientActivity.java
@@ -141,8 +141,10 @@ public class AddEditPatientActivity extends ACBaseActivity {
                 finish();
             });
         alertDialog = alertDialogBuilder.create();
-        alertDialog.getButton(AlertDialog.BUTTON_POSITIVE).setTextColor(getResources().getColor(R.color.neutral_green));
-        alertDialog.getButton(AlertDialog.BUTTON_NEGATIVE).setTextColor(getResources().getColor(R.color.neutral_green));
+        alertDialog.setOnShowListener(dialogInterface -> {
+            alertDialog.getButton(AlertDialog.BUTTON_POSITIVE).setTextColor(getResources().getColor(R.color.neutral_green));
+            alertDialog.getButton(AlertDialog.BUTTON_NEGATIVE).setTextColor(getResources().getColor(R.color.neutral_green));
+        });
         alertDialog.show();
     }
 

--- a/openmrs-client/src/main/java/org/openmrs/mobile/activities/addeditpatient/AddEditPatientActivity.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/activities/addeditpatient/AddEditPatientActivity.java
@@ -128,7 +128,7 @@ public class AddEditPatientActivity extends ACBaseActivity {
      */
     private void showInfoLostDialog() {
         AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(
-                this);
+                this,R.style.AlertDialogTheme);
         alertDialogBuilder.setTitle(R.string.dialog_title_reset_patient);
         // set dialog message
         alertDialogBuilder
@@ -141,10 +141,6 @@ public class AddEditPatientActivity extends ACBaseActivity {
                 finish();
             });
         alertDialog = alertDialogBuilder.create();
-        alertDialog.setOnShowListener(dialogInterface -> {
-            alertDialog.getButton(AlertDialog.BUTTON_POSITIVE).setTextColor(getResources().getColor(R.color.neutral_green));
-            alertDialog.getButton(AlertDialog.BUTTON_NEGATIVE).setTextColor(getResources().getColor(R.color.neutral_green));
-        });
         alertDialog.show();
     }
 

--- a/openmrs-client/src/main/java/org/openmrs/mobile/activities/addeditpatient/AddEditPatientFragment.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/activities/addeditpatient/AddEditPatientFragment.java
@@ -919,8 +919,10 @@ public class AddEditPatientFragment extends ACBaseFragment<AddEditPatientContrac
                         alertDialog.cancel();
                     });
                 alertDialog = alertDialogBuilder.create();
-                alertDialog.getButton(AlertDialog.BUTTON_POSITIVE).setTextColor(getResources().getColor(R.color.neutral_green));
-                alertDialog.getButton(AlertDialog.BUTTON_NEGATIVE).setTextColor(getResources().getColor(R.color.neutral_green));
+                alertDialog.setOnShowListener(dialogInterface -> {
+                    alertDialog.getButton(AlertDialog.BUTTON_POSITIVE).setTextColor(getResources().getColor(R.color.neutral_green));
+                    alertDialog.getButton(AlertDialog.BUTTON_NEGATIVE).setTextColor(getResources().getColor(R.color.neutral_green));
+                });
                 alertDialog.show();
             } else {
                 mPresenter.confirmUpdate(updatePatient(updatedPatient));

--- a/openmrs-client/src/main/java/org/openmrs/mobile/activities/addeditpatient/AddEditPatientFragment.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/activities/addeditpatient/AddEditPatientFragment.java
@@ -919,6 +919,8 @@ public class AddEditPatientFragment extends ACBaseFragment<AddEditPatientContrac
                         alertDialog.cancel();
                     });
                 alertDialog = alertDialogBuilder.create();
+                alertDialog.getButton(AlertDialog.BUTTON_POSITIVE).setTextColor(getResources().getColor(R.color.neutral_green));
+                alertDialog.getButton(AlertDialog.BUTTON_NEGATIVE).setTextColor(getResources().getColor(R.color.neutral_green));
                 alertDialog.show();
             } else {
                 mPresenter.confirmUpdate(updatePatient(updatedPatient));

--- a/openmrs-client/src/main/java/org/openmrs/mobile/activities/addeditpatient/AddEditPatientFragment.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/activities/addeditpatient/AddEditPatientFragment.java
@@ -905,7 +905,7 @@ public class AddEditPatientFragment extends ACBaseFragment<AddEditPatientContrac
     private void submitAction() {
         if (isUpdatePatient) {
             if (binding.deceasedCheckbox.isChecked() && !causeOfDeathUUID.isEmpty()) {
-                AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(getContext());
+                AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(getContext(),R.style.AlertDialogTheme);
                 alertDialogBuilder.setTitle(R.string.mark_patient_deceased);
                 // set dialog message
                 alertDialogBuilder
@@ -919,10 +919,6 @@ public class AddEditPatientFragment extends ACBaseFragment<AddEditPatientContrac
                         alertDialog.cancel();
                     });
                 alertDialog = alertDialogBuilder.create();
-                alertDialog.setOnShowListener(dialogInterface -> {
-                    alertDialog.getButton(AlertDialog.BUTTON_POSITIVE).setTextColor(getResources().getColor(R.color.neutral_green));
-                    alertDialog.getButton(AlertDialog.BUTTON_NEGATIVE).setTextColor(getResources().getColor(R.color.neutral_green));
-                });
                 alertDialog.show();
             } else {
                 mPresenter.confirmUpdate(updatePatient(updatedPatient));

--- a/openmrs-client/src/main/java/org/openmrs/mobile/activities/patientdashboard/allergy/PatientAllergyFragment.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/activities/patientdashboard/allergy/PatientAllergyFragment.java
@@ -137,8 +137,10 @@ public class PatientAllergyFragment extends PatientDashboardFragment implements 
                         alertDialog.cancel();
                     });
             alertDialog = alertDialogBuilder.create();
-            alertDialog.getButton(AlertDialog.BUTTON_POSITIVE).setTextColor(getResources().getColor(R.color.neutral_green));
-            alertDialog.getButton(AlertDialog.BUTTON_NEGATIVE).setTextColor(getResources().getColor(R.color.neutral_green));
+            alertDialog.setOnShowListener(dialogInterface -> {
+                alertDialog.getButton(AlertDialog.BUTTON_POSITIVE).setTextColor(getResources().getColor(R.color.neutral_green));
+                alertDialog.getButton(AlertDialog.BUTTON_NEGATIVE).setTextColor(getResources().getColor(R.color.neutral_green));
+            });
             alertDialog.show();
         } else {
             Intent intent = new Intent(getActivity(), AddEditAllergyActivity.class);

--- a/openmrs-client/src/main/java/org/openmrs/mobile/activities/patientdashboard/allergy/PatientAllergyFragment.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/activities/patientdashboard/allergy/PatientAllergyFragment.java
@@ -137,6 +137,8 @@ public class PatientAllergyFragment extends PatientDashboardFragment implements 
                         alertDialog.cancel();
                     });
             alertDialog = alertDialogBuilder.create();
+            alertDialog.getButton(AlertDialog.BUTTON_POSITIVE).setTextColor(getResources().getColor(R.color.neutral_green));
+            alertDialog.getButton(AlertDialog.BUTTON_NEGATIVE).setTextColor(getResources().getColor(R.color.neutral_green));
             alertDialog.show();
         } else {
             Intent intent = new Intent(getActivity(), AddEditAllergyActivity.class);

--- a/openmrs-client/src/main/java/org/openmrs/mobile/activities/patientdashboard/allergy/PatientAllergyFragment.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/activities/patientdashboard/allergy/PatientAllergyFragment.java
@@ -123,7 +123,7 @@ public class PatientAllergyFragment extends PatientDashboardFragment implements 
     @Override
     public void performFunction(int position) {
         if (position == 1) {
-            AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(getContext());
+            AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(getContext(),R.style.AlertDialogTheme);
             alertDialogBuilder.setTitle(getString(R.string.delete_allergy_title, selectedAllergy.getAllergen().getCodedAllergen().getDisplay()));
             alertDialogBuilder
                     .setMessage(R.string.delete_allergy_description)
@@ -137,10 +137,6 @@ public class PatientAllergyFragment extends PatientDashboardFragment implements 
                         alertDialog.cancel();
                     });
             alertDialog = alertDialogBuilder.create();
-            alertDialog.setOnShowListener(dialogInterface -> {
-                alertDialog.getButton(AlertDialog.BUTTON_POSITIVE).setTextColor(getResources().getColor(R.color.neutral_green));
-                alertDialog.getButton(AlertDialog.BUTTON_NEGATIVE).setTextColor(getResources().getColor(R.color.neutral_green));
-            });
             alertDialog.show();
         } else {
             Intent intent = new Intent(getActivity(), AddEditAllergyActivity.class);

--- a/openmrs-client/src/main/res/values/styles_openmrs.xml
+++ b/openmrs-client/src/main/res/values/styles_openmrs.xml
@@ -71,4 +71,8 @@
         <item name="android:textSize">22sp</item>
     </style>
 
+    <style name="AlertDialogTheme" parent="ThemeOverlay.MaterialComponents.Dialog.Alert">
+        <item name="colorPrimary">@color/neutral_green</item>
+    </style>
+
 </resources>


### PR DESCRIPTION
## Description of what I changed
The color of buttons of edit text was not visible clearly in the dark mode earlier. Changed them to a color visible in both light and dark mode.

## Issue I worked on
JIRA Issue: https://issues.openmrs.org/browse/AC-961

## Checklist: I completed these to help reviewers :)
- [x] My pull request only contains **ONE single commit**
(the number above, next to the 'Commits' tab is 1).

- [ ] I have **added tests** to cover my changes. (If you refactored
existing code that was well tested you do not have to add tests)

- [x] All new and existing **tests passed**.

- [x] My pull request is **based on the latest changes** of the master branch.