### PR TITLE
AC-963 : In Patient Registration, date of birth edit text's keyboard/input type does not have forward slash.

### DIFF
--- a/.idea/runConfigurations.xml
+++ b/.idea/runConfigurations.xml
@@ -3,6 +3,7 @@
   <component name="RunConfigurationProducerService">
     <option name="ignoredProducers">
       <set>
+        <option value="com.android.tools.idea.compose.preview.runconfiguration.ComposePreviewRunConfigurationProducer" />
         <option value="org.jetbrains.plugins.gradle.execution.test.runner.AllInPackageGradleConfigurationProducer" />
         <option value="org.jetbrains.plugins.gradle.execution.test.runner.TestClassGradleConfigurationProducer" />
         <option value="org.jetbrains.plugins.gradle.execution.test.runner.TestMethodGradleConfigurationProducer" />

--- a/openmrs-client/src/main/java/org/openmrs/mobile/activities/addeditpatient/AddEditPatientFragment.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/activities/addeditpatient/AddEditPatientFragment.java
@@ -140,6 +140,33 @@ public class AddEditPatientFragment extends ACBaseFragment<AddEditPatientContrac
                              Bundle savedInstanceState) {
         binding = FragmentPatientInfoBinding.inflate(inflater, container, false);
         setHasOptionsMenu(true);
+        binding.dobEditText .addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+
+            }
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) {
+                String str=binding.dobEditText .getText().toString();
+                int textLength=binding.dobEditText .getText().length();
+                if (textLength == 3) {
+                    if (!str.contains("/")) {
+                        binding.dobEditText .setText(new StringBuilder(binding.dobEditText .getText().toString()).insert(str.length() - 1, "/").toString());
+                        binding.dobEditText .setSelection(binding.dobEditText .getText().length());
+                    }
+                }if (textLength == 6) {
+                    if (!str.substring(3).contains("/")) {
+                        binding.dobEditText .setText(new StringBuilder(binding.dobEditText .getText().toString()).insert(str.length() - 1, "/").toString());
+                        binding.dobEditText .setSelection(binding.dobEditText .getText().length());
+                    }
+                }
+            }
+
+            @Override
+            public void afterTextChanged(Editable s) {
+
+            }
+        });
         addListeners();
         initializePlaces(mPresenter.getPlaces());
         fillFields(mPresenter.getPatientToUpdate());
@@ -601,7 +628,7 @@ public class AddEditPatientFragment extends ACBaseFragment<AddEditPatientContrac
 
             DatePickerDialog mDatePicker = new DatePickerDialog(AddEditPatientFragment.this.getActivity(), (datePicker, selectedYear, selectedMonth, selectedDay) -> {
                 int adjustedMonth = selectedMonth + 1;
-                binding.dobEditText.setText(selectedDay + "/" + adjustedMonth + "/" + selectedYear);
+                binding.dobEditText.setText(String.format("%02d",selectedDay) + "/" +String.format("%02d",adjustedMonth)   + "/" + selectedYear);
                 birthDate = new LocalDate(selectedYear, adjustedMonth, selectedDay);
                 bdt = birthDate.toDateTimeAtStartOfDay().toDateTime();
             }, cYear, cMonth, cDay);

--- a/openmrs-client/src/main/res/layout/fragment_patient_info.xml
+++ b/openmrs-client/src/main/res/layout/fragment_patient_info.xml
@@ -371,7 +371,8 @@
                                     android:inputType="datetime"
                                     android:maxLines="1"
                                     android:nextFocusDown="@+id/estimatedYear"
-                                    android:textSize="14sp" />
+                                    android:textSize="14sp"
+                                    android:maxLength="10"/>
                             </com.google.android.material.textfield.TextInputLayout>
 
                             <ImageButton
@@ -387,7 +388,8 @@
                                 android:background="@drawable/ic_date_range_24dp"
                                 app:layout_constraintBottom_toBottomOf="@id/textInputLayoutDOB"
                                 app:layout_constraintRight_toRightOf="@id/textInputLayoutDOB"
-                                app:layout_constraintTop_toTopOf="@id/textInputLayoutDOB" />
+                                app:layout_constraintTop_toTopOf="@id/textInputLayoutDOB"
+                                android:backgroundTint="@color/black"/>
 
                             <TextView
                                 android:layout_width="0dp"

--- a/openmrs-client/src/main/res/layout/fragment_patient_info.xml
+++ b/openmrs-client/src/main/res/layout/fragment_patient_info.xml
@@ -389,7 +389,7 @@
                                 app:layout_constraintBottom_toBottomOf="@id/textInputLayoutDOB"
                                 app:layout_constraintRight_toRightOf="@id/textInputLayoutDOB"
                                 app:layout_constraintTop_toTopOf="@id/textInputLayoutDOB"
-                                android:backgroundTint="@color/black"/>
+                                android:backgroundTint="?android:attr/textColorPrimary"/>
 
                             <TextView
                                 android:layout_width="0dp"


### PR DESCRIPTION
## Issue AC-963 : 
In Patient Registration, date of birth edit text's keyboard/input type does not have forward slash. [link here](https://issues.openmrs.org/browse/AC-963)

## Description of what I changed

What I changed :
In Patient Registration, date of birth edit text's keyboard/input type does have forward slash and make calender ImageButton visible and selected date from datepicker will co




#AC-963 Issue I worked on

Details of changes
-Add 2 if condition to add slash (/) after date,month and add maxLength property to dobEditText 
-Add backgroundTint to ImageButton of calender

## Test app after changes

image1 :
![ac963](https://user-images.githubusercontent.com/75332758/133308703-4343a783-60d0-4223-824b-b65c74ba8ce2.jpg)
image2 :
![ac-963](https://user-images.githubusercontent.com/75332758/133308708-c77dd122-8b98-4c62-8508-ac7bffea532f.jpg)

Video - > https://user-images.githubusercontent.com/75332758/133309270-7b9703f3-78d2-4639-9748-364bcb71c831.mp4
