### PR TITLE
Improve GRADLE build Performance

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,3 +19,5 @@ org.gradle.jvmargs=-Xmx4608m
 
 android.useAndroidX=true
 android.enableJetifier=true
+org.gradle.caching = true
+org.gradle.vfs.watch = true


### PR DESCRIPTION

[File system watching](https://blog.gradle.org/introducing-file-system-watching). Since Gradle 6.5, File system watching was introduced which can help to avoid unnecessary I/O. This feature is the default since 7.0. For an older version, we can enable this feature by setting `org.gradle.vfs.watch=true`.

[gradle caching](https://docs.gradle.org/current/userguide/build_cache.html). Shared caches can reduce the number of tasks you need to execute by reusing outputs already generated elsewhere. This can significantly decrease build times. We can enable this feature by setting `org.gradle.caching=true`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
